### PR TITLE
Visual/mapstyle

### DIFF
--- a/App/frontend/package-lock.json
+++ b/App/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "is-218-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "maplibre-gl": "^2.4.0"
+        "maplibre-gl": "^4.7.1"
       },
       "devDependencies": {
         "typescript": "^4.9.5"
@@ -34,12 +34,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/@mapbox/mapbox-gl-supported": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz",
-      "integrity": "sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@mapbox/point-geometry": {
       "version": "0.1.0",
@@ -77,11 +71,46 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
+      "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/mapbox__point-geometry": {
       "version": "0.1.4",
@@ -106,22 +135,25 @@
       "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
       "license": "MIT"
     },
-    "node_modules/csscolorparser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
-      "license": "MIT"
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/earcut": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
       "license": "ISC"
     },
     "node_modules/geojson-vt": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
-      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
       "license": "ISC"
     },
     "node_modules/get-stream": {
@@ -143,17 +175,17 @@
       "license": "MIT"
     },
     "node_modules/global-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
+      "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
       "license": "MIT",
       "dependencies": {
-        "ini": "^1.3.5",
-        "kind-of": "^6.0.2",
-        "which": "^1.3.1"
+        "ini": "^4.1.3",
+        "kind-of": "^6.0.3",
+        "which": "^4.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=16"
       }
     },
     "node_modules/ieee754": {
@@ -177,21 +209,33 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC"
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
     },
     "node_modules/kdbush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
-      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
       "license": "ISC"
     },
     "node_modules/kind-of": {
@@ -204,36 +248,44 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-2.4.0.tgz",
-      "integrity": "sha512-csNFylzntPmHWidczfgCZpvbTSmhaWvLRj9e1ezUDBEPizGgshgm3ea1T5TCNEEBq0roauu7BPuRZjA3wO4KqA==",
-      "hasInstallScript": true,
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
+      "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^2.0.1",
         "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^2.0.5",
+        "@mapbox/tiny-sdf": "^2.0.6",
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@types/geojson": "^7946.0.10",
-        "@types/mapbox__point-geometry": "^0.1.2",
-        "@types/mapbox__vector-tile": "^1.3.0",
-        "@types/pbf": "^3.0.2",
-        "csscolorparser": "~1.0.3",
-        "earcut": "^2.2.4",
-        "geojson-vt": "^3.2.1",
+        "@maplibre/maplibre-gl-style-spec": "^20.3.1",
+        "@types/geojson": "^7946.0.14",
+        "@types/geojson-vt": "3.2.5",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
+        "earcut": "^3.0.0",
+        "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.3",
-        "global-prefix": "^3.0.0",
+        "global-prefix": "^4.0.0",
+        "kdbush": "^4.0.2",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^1.0.2",
-        "quickselect": "^2.0.0",
-        "supercluster": "^7.1.5",
-        "tinyqueue": "^2.0.3",
+        "pbf": "^3.3.0",
+        "potpack": "^2.0.0",
+        "quickselect": "^3.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^3.0.0",
         "vt-pbf": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
     "node_modules/minimist": {
@@ -265,9 +317,9 @@
       }
     },
     "node_modules/potpack": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
-      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
       "license": "ISC"
     },
     "node_modules/protocol-buffers-schema": {
@@ -277,9 +329,9 @@
       "license": "MIT"
     },
     "node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
       "license": "ISC"
     },
     "node_modules/resolve-protobuf-schema": {
@@ -291,19 +343,25 @@
         "protocol-buffers-schema": "^3.3.1"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/supercluster": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
-      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
       "license": "ISC",
       "dependencies": {
-        "kdbush": "^3.0.0"
+        "kdbush": "^4.0.2"
       }
     },
     "node_modules/tinyqueue": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "license": "ISC"
     },
     "node_modules/typescript": {
@@ -332,15 +390,18 @@
       }
     },
     "node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
       "license": "ISC",
       "dependencies": {
-        "isexe": "^2.0.0"
+        "isexe": "^3.1.1"
       },
       "bin": {
-        "which": "bin/which"
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     }
   }

--- a/App/frontend/package.json
+++ b/App/frontend/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "is-218-frontend",
   "version": "0.1.0",
   "private": true,
@@ -7,7 +7,7 @@
     "watch": "tsc -w -p ."
   },
   "dependencies": {
-    "maplibre-gl": "^2.4.0"
+    "maplibre-gl": "^4.7.1"
   },
   "devDependencies": {
     "typescript": "^4.9.5"

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -1,6 +1,7 @@
 ﻿// Use the global provided by the CDN instead of importing a node-style package
 import type * as MaplibreGL from 'maplibre-gl';
-import {LngLatLike} from "maplibre-gl";
+import {LngLatLike, PropertyValueSpecification} from "maplibre-gl";
+
 
 declare global {
   interface Window {
@@ -18,32 +19,165 @@ if (!maplibregl) {
   // Create a local `map` variable so TypeScript knows it's defined when we call methods on it.
   const map = new maplibregl.Map({
     container: 'map' as string,
-    style: 'https://tiles.openfreemap.org/styles/positron' as string,
+    style: '../static/style/mapstyle.json' as string,
     center: [0, 0] as LngLatLike,
     zoom: 6 as number,
   });
 
   window.map = map;
 
-  map.on('style.load', () => {
-    map.setProjection({
-      type: 'globe',
-    });
-  });
-
   const geolocate = new maplibregl.GeolocateControl({
     positionOptions: { enableHighAccuracy: true as boolean },
     trackUserLocation: true as boolean,
     showAccuracyCircle: true as boolean,
-  });
 
+  });
   map.addControl(geolocate, 'top-right');
+
   map.on('load', () => {
     try {
       geolocate?.trigger();
     }
     catch (err) {
       console.warn('Geolocate trigger failed:', err);
+    }
+  });
+
+  const scale = new maplibregl.ScaleControl({ maxWidth: 320, unit: 'metric' });
+  map.addControl(scale, 'bottom-left');
+
+  map.on('style.load', () => {
+    map.setProjection({
+      type: 'globe',
+    });
+
+    const LIGHT_THETA_DEG : number = -37;
+    const LIGHT_PHI_DEG : number = 4;
+    const LIGHT_RADIAL_DIST : number = 300000.0;
+    const LIGHT_COLOR : string = '#ffffff';
+
+    // Maximum light intensity when fully zoomed out (globe view)
+    // Maximum atmosphere-blend when fully zoomed out (1.0 = full atmosphere glow)
+    const  LIGHT_INTENSITY_MAX : number = 1.0 as number;
+    const ATMOSPHERE_BLEND_MAX : number = 1.0 as number;
+
+    // Zoom range over which globe effects (light, atmosphere, dark colors)
+    // are fully active vs. fully faded out to the normal map style.
+    // At or below FADE_ZOOM_START everything is in "globe/dark" mode.
+    // At or above FADE_ZOOM_END everything matches the original bright style.
+    const FADE_ZOOM_START : number = 3;
+    const FADE_ZOOM_END : number = 8;
+
+    // Calculate light position (radial distance, azimuthal angle, polar angle)
+    const p = (Math.acos(Math.cos((LIGHT_THETA_DEG / 180 as number + 1 as number) * Math.PI)
+        * Math.cos((LIGHT_PHI_DEG / 180 as number) * Math.PI)) / Math.PI) * 180 as number;
+    const a = 90 as number + (Math.atan2(
+      Math.sin((LIGHT_PHI_DEG / 180 as number) * Math.PI),
+      Math.sin((LIGHT_THETA_DEG / 180 as number + 1 as number) * Math.PI) * Math.cos((LIGHT_PHI_DEG / 180 as number) * Math.PI)
+    ) / Math.PI) * 180 as number;
+
+    //interpolate a value between two zoom stops
+    function lerpAtZoom(zoom: number, z1: number, v1: number, z2: number, v2: number): number {
+      if (zoom <= z1) return v1;
+      if (zoom >= z2) return v2;
+      return v1 + (v2 - v1) * ((zoom - z1) / (z2 - z1));
+    }
+
+    //fade light intensity over zoom range so brightness fades consistently with zoom level
+    function updateLightForZoom() {
+      const z : number = map.getZoom();
+      const intensity : number = lerpAtZoom(z, FADE_ZOOM_START, LIGHT_INTENSITY_MAX, FADE_ZOOM_END, 0);
+      map.setLight({
+        anchor: 'map' as PropertyValueSpecification<"map">,
+        position: [LIGHT_RADIAL_DIST, a, p],
+        intensity: intensity as number,
+        color: LIGHT_COLOR as string,
+      });
+    }
+
+    updateLightForZoom(); //set initial light
+    map.on('zoom', updateLightForZoom);
+
+    // Set sky – atmosphere-blend fades out/in-step with the light intensity
+    map.setSky({
+      'atmosphere-blend': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        0, ATMOSPHERE_BLEND_MAX,
+        FADE_ZOOM_START, ATMOSPHERE_BLEND_MAX,
+        FADE_ZOOM_END, 0
+      ],
+    });
+
+    //dark style for on globe view, to properly show the contrast between day and night
+    const darkPaint: [string, string, string, string][] = [
+      ['background',          'background-color', 'rgb(11, 11, 15)',    'rgb(242, 243, 240)'],
+      ['water',               'fill-color',       'rgb(5, 8, 18)',    'rgb(194, 200, 202)'],
+      ['water',               'fill-outline-color','rgb(3, 5, 14)',    'rgb(194, 200, 202)'],
+      ['park',                'fill-color',       'rgb(8, 12, 8)',    'rgb(230, 233, 229)'],
+      ['landcover_ice_shelf', 'fill-color',       'rgb(12, 12, 14)',  'hsl(0, 0%, 98%)'],
+      ['landcover_glacier',   'fill-color',       'rgb(12, 12, 14)',  'hsl(0, 0%, 98%)'],
+      ['landuse_residential', 'fill-color',       'rgb(10, 10, 12)',  'rgb(234, 234, 230)'],
+      ['landcover_wood',      'fill-color',       'rgb(6, 10, 6)',    'rgb(230, 233, 229)'],
+      ['building',            'fill-color',       'rgb(14, 14, 16)',  'rgb(234, 234, 229)'],
+      ['building',            'fill-outline-color','rgb(10, 10, 12)', 'rgb(219, 219, 218)'],
+      ['waterway',            'line-color',       'rgb(5, 8, 18)',    'rgb(194, 200, 202)'],
+      ['boundary_2',          'line-color',       'rgb(5, 5, 8)',       'hsl(0, 0%, 70%)'],
+      ['boundary_3',          'line-color',       'rgb(5, 5, 8)',       'hsl(0, 0%, 70%)'],
+      ['boundary_disputed',   'line-color',       'rgb(5, 5, 8)',       'hsl(0, 0%, 70%)'],
+      ['label_country_1',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
+      ['label_country_1',     'text-halo-color',  'rgb(2, 2, 4)',      '#ffffff'],
+      ['label_country_2',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
+      ['label_country_2',     'text-halo-color',  'rgb(2, 2, 4)',      '#ffffff'],
+      ['label_country_3',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
+      ['label_country_3',     'text-halo-color',  'rgb(2, 2, 4)',      '#ffffff'],
+      ['label_city',          'text-color',       'rgb(35, 35, 45)',    '#000000'],
+      ['label_city',          'text-halo-color',  'rgb(2, 2, 4)',      '#ffffff'],
+      ['label_city_capital',  'text-color',       'rgb(35, 35, 45)',    '#000000'],
+      ['label_city_capital',  'text-halo-color',  'rgb(2, 2, 4)',      '#ffffff'],
+      ['label_town',          'text-color',       'rgb(35, 35, 45)',    '#000000'],
+      ['label_town',          'text-halo-color',  'rgb(2, 2, 4)',      '#ffffff'],
+      ['label_state',         'text-color',       'rgb(35, 35, 45)',    '#333333'],
+      ['label_state',         'text-halo-color',  'rgb(2, 2, 4)',      '#ffffff'],
+      ['waterway_line_label',   'text-halo-color', 'rgba(2, 2, 4, 0.7)',  'rgba(255, 255, 255, 0.7)'],
+      ['waterway_line_label',   'text-color',      'rgb(20, 25, 40)',     'hsl(0, 0%, 66%)'],
+      ['water_name_point_label','text-halo-color',  'rgba(2, 2, 4, 0.7)', 'rgba(255, 255, 255, 0.7)'],
+      ['water_name_point_label','text-color',       'rgb(15, 20, 45)',    '#495e91'],
+      ['water_name_line_label', 'text-halo-color',  'rgba(2, 2, 4, 0.7)', 'rgba(255, 255, 255, 0.7)'],
+      ['water_name_line_label', 'text-color',       'rgb(15, 20, 45)',    '#495e91'],
+      ['tunnel_motorway_casing',        'line-color', 'rgb(10, 10, 14)',  'rgb(213, 213, 213)'],
+      ['highway_major_casing',          'line-color', 'rgb(10, 10, 14)',  'rgb(213, 213, 213)'],
+      ['highway_motorway_casing',       'line-color', 'rgb(10, 10, 14)',  'rgb(213, 213, 213)'],
+      ['highway_motorway_bridge_casing','line-color', 'rgb(10, 10, 14)',  'rgb(213, 213, 213)'],
+      ['tunnel_motorway_inner',         'line-color', 'rgb(12, 12, 16)',  'rgb(234, 234, 234)'],
+      ['highway_major_inner',           'line-color', 'rgb(12, 12, 16)',  '#ffffff'],
+      ['highway_motorway_inner',        'line-color', 'rgb(12, 12, 16)',  '#ffffff'],
+      ['highway_motorway_bridge_inner', 'line-color', 'rgb(12, 12, 16)',  '#ffffff'],
+      ['highway_major_subtle',          'line-color', 'rgba(10,10,14,0.69)', 'hsla(0,0%,85%,0.69)'],
+      ['highway_motorway_subtle',       'line-color', 'rgba(10,10,14,0.53)', 'hsla(0,0%,85%,0.53)'],
+      ['highway_path',                  'line-color', 'rgb(12, 12, 16)',  'rgb(234, 234, 234)'],
+      ['highway_minor',                 'line-color', 'rgb(10, 10, 14)',  'hsl(0, 0%, 88%)'],
+      ['road_area_pier',                'fill-color', 'rgb(8, 8, 12)',    'rgb(242, 243, 240)'],
+      ['road_pier',                     'line-color', 'rgb(8, 8, 12)',    'rgb(242, 243, 240)'],
+      ['railway',                       'line-color', 'rgb(10, 10, 14)',  '#dddddd'],
+      ['railway_dashline',              'line-color', 'rgb(12, 12, 16)',  '#fafafa'],
+      ['railway_transit',               'line-color', 'rgb(10, 10, 14)',  '#dddddd'],
+      ['railway_transit_dashline',      'line-color', 'rgb(12, 12, 16)',  '#fafafa'],
+      ['railway_service',               'line-color', 'rgb(10, 10, 14)',  '#dddddd'],
+      ['railway_service_dashline',      'line-color', 'rgb(12, 12, 16)',  '#fafafa'],
+    ];
+    for (const entry of darkPaint) {
+      if (map.getLayer(entry[0])) {
+        map.setPaintProperty(entry[0], entry[1], [
+          'interpolate',
+          ['linear'],
+          ['zoom'],
+          0, entry[2],
+          FADE_ZOOM_START, entry[2],
+          FADE_ZOOM_END, entry[3],
+        ]);
+      }
     }
   });
 }

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -48,7 +48,7 @@ if (!maplibregl) {
 
   map.on('style.load', () => {
     map.setProjection({
-      type: 'globe',
+      type: 'globe' as string,
     });
 
     // Stars layer
@@ -56,8 +56,8 @@ if (!maplibregl) {
       try {
         const starsLayer = createStarsLayer({
           id: 'stars',
-          intensity: 1.0,
-          density: 0.15,
+          intensity: 1.0 as number,
+          density: 0.55 as number,
         });
         if (!map.getLayer('stars')) {
           const layers : LayerSpecification[] = map.getStyle().layers;

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -85,8 +85,8 @@ if (!maplibregl) {
     // are fully active vs. fully faded out to the normal map style.
     // At or below FADE_ZOOM_START everything is in "globe/dark" mode.
     // At or above FADE_ZOOM_END everything matches the original bright style.
-    const FADE_ZOOM_START : number = 3;
-    const FADE_ZOOM_END : number = 8;
+    const FADE_ZOOM_START : number = 6;
+    const FADE_ZOOM_END : number = 10;
 
     // Calculate light position (radial distance, azimuthal angle, polar angle)
     const p = (Math.acos(Math.cos((LIGHT_THETA_DEG / 180 as number + 1 as number) * Math.PI)

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -1,6 +1,6 @@
 ﻿// Use the global provided by the CDN instead of importing a node-style package
 import type * as MaplibreGL from 'maplibre-gl';
-import {LngLatLike, PropertyValueSpecification} from "maplibre-gl";
+import {AddLayerObject, LayerSpecification, LngLatLike, PropertyValueSpecification} from "maplibre-gl";
 
 
 declare global {
@@ -49,6 +49,26 @@ if (!maplibregl) {
   map.on('style.load', () => {
     map.setProjection({
       type: 'globe',
+    });
+
+    // Stars layer
+    import("./starsLayer.js").then(({ createStarsLayer }) => {
+      try {
+        const starsLayer = createStarsLayer({
+          id: 'stars',
+          intensity: 1.0,
+          density: 0.15,
+        });
+        if (!map.getLayer('stars')) {
+          const layers : LayerSpecification[] = map.getStyle().layers;
+          const firstLayerId : string | undefined = layers && layers.length > 0 ? layers[0].id : undefined;
+          map.addLayer(starsLayer as AddLayerObject, firstLayerId);
+        }
+      } catch (err) {
+        console.warn('Failed to add stars layer:', err);
+      }
+    }).catch((err: any) => {
+      console.warn('Failed to load starsLayer module:', err);
     });
 
     const LIGHT_THETA_DEG : number = -37;

--- a/App/frontend/src/starsLayer.ts
+++ b/App/frontend/src/starsLayer.ts
@@ -105,41 +105,52 @@ export function createStarsLayer(options: StarsLayerOptions = {}) {
               -rotated.x * sinLng + rotated.z * cosLng
             );
 
-            // Convert to spherical coordinates
-            float lng = atan(rotated.x, rotated.z);
-            float lat = asin(rotated.y);
+            // ── Star field using cube-map projection ──────────────
+            // Project the rotated direction onto the dominant cube face
+            // and hash in that 2D space.  This avoids the equirectangular
+            // pole singularity entirely — stars are uniform everywhere.
 
-            vec2 uv = vec2(
-              (lng / PI) * 0.5 + 0.5,
-              (lat / (PI * 0.5)) * 0.5 + 0.5
-            );
+            vec3 absDir = abs(rotated);
+            vec2 faceUV;
+            float faceIndex;
 
-            // Create star field via hashed grid
-            vec2 scaledUV = uv * 200.0;
+            if (absDir.x >= absDir.y && absDir.x >= absDir.z) {
+              // ±X face
+              faceUV = rotated.yz / absDir.x;
+              faceIndex = rotated.x > 0.0 ? 0.0 : 1.0;
+            } else if (absDir.y >= absDir.x && absDir.y >= absDir.z) {
+              // ±Y face
+              faceUV = rotated.xz / absDir.y;
+              faceIndex = rotated.y > 0.0 ? 2.0 : 3.0;
+            } else {
+              // ±Z face
+              faceUV = rotated.xy / absDir.z;
+              faceIndex = rotated.z > 0.0 ? 4.0 : 5.0;
+            }
+
+            // faceUV is in [-1, 1], remap to [0, 1]
+            faceUV = faceUV * 0.5 + 0.5;
+
+            // Scale to create grid cells per face
+            float gridScale = 60.0;
+            vec2 scaledUV = faceUV * gridScale;
             vec2 gridPos = floor(scaledUV);
-            float hash = fract(sin(dot(gridPos, vec2(12.9898, 78.233))) * 43758.5453);
+
+            // Include face index in hash to avoid star duplication across faces
+            float faceHash = faceIndex * 17.0;
+            float hash = fract(sin(dot(gridPos + faceHash, vec2(12.9898, 78.233))) * 43758.5453);
 
             float stars = 0.0;
             if (hash > ${(1 - density).toFixed(2)}) {
-              float hashX = fract(sin(dot(gridPos, vec2(127.1, 311.7))) * 43758.5453);
-              float hashY = fract(sin(dot(gridPos, vec2(269.5, 183.3))) * 43758.5453);
+              float hashX = fract(sin(dot(gridPos + faceHash, vec2(127.1, 311.7))) * 43758.5453);
+              float hashY = fract(sin(dot(gridPos + faceHash, vec2(269.5, 183.3))) * 43758.5453);
               vec2 randomOffset = vec2(hashX, hashY);
               vec2 localPos = fract(scaledUV);
-              vec2 delta = (localPos - randomOffset);
-
-              // Correct for equirectangular projection distortion so stars
-              // are circular at every latitude.
-              // Grid cells span (2π/gridSize) in longitude but only
-              // (π/gridSize) in latitude — twice as wide angularly.
-              // Scaling delta.x by 2 makes a unit step in x represent
-              // the same angular distance as a unit step in y.
-              // cos(lat) further corrects for meridian convergence at poles.
-              float aspect = 2.0 * max(0.1, cos(lat));
-              delta.x *= aspect;
+              vec2 delta = localPos - randomOffset;
 
               float dist = length(delta);
-              float sizeHash = fract(sin(dot(gridPos, vec2(415.2, 371.9))) * 43758.5453);
-              float starSize = 0.05 + 0.1 * sizeHash;
+              float sizeHash = fract(sin(dot(gridPos + faceHash, vec2(415.2, 371.9))) * 43758.5453);
+              float starSize = 0.025 + 0.025 * sizeHash;
 
               stars = 1.0 - smoothstep(0.0, starSize, dist);
               stars = pow(stars, 4.0);

--- a/App/frontend/src/starsLayer.ts
+++ b/App/frontend/src/starsLayer.ts
@@ -1,0 +1,294 @@
+﻿/**
+ * MapLibre GL JS Stars Custom Layer (TypeScript)
+ *
+ * Adds a procedural starry background to globe projection views using a custom layer.
+ * Stars are generated in a fragment shader and properly rotate with the globe camera.
+ */
+
+export interface StarsLayerOptions {
+  id?: string;
+  intensity?: number;
+  density?: number;
+}
+
+export function createStarsLayer(options: StarsLayerOptions = {}) {
+  const intensity = options.intensity || 20.0;
+  const density = options.density || 0.15;
+
+  // State held by the layer instance
+  let layerMap: any = null;
+  let program: WebGLProgram | null = null;
+  let vertexBuffer: WebGLBuffer | null = null;
+  let indexBuffer: WebGLBuffer | null = null;
+  let aPos = -1;
+
+  return {
+    id: options.id || 'stars',
+    type: 'custom' as const,
+    renderingMode: '3d' as const,
+
+    onAdd: function (map: any, gl: WebGLRenderingContext) {
+      layerMap = map;
+
+      try {
+        // ── Vertex shader ─────────────────────────────────────────
+        const vertexSource = `
+          attribute vec2 a_pos;
+          uniform mat4 u_inv_proj_matrix;
+          varying vec3 view_direction;
+
+          void main() {
+            view_direction = (u_inv_proj_matrix * vec4(a_pos, 0.0, 1.0)).xyz;
+            gl_Position = vec4(a_pos, 1.0, 1.0);
+          }
+        `;
+
+        // ── Fragment shader ───────────────────────────────────────
+        const fragmentSource = `
+          precision highp float;
+          varying vec3 view_direction;
+
+          uniform vec3 u_globe_position;
+          uniform float u_globe_radius;
+          uniform float u_stars_intensity;
+          uniform vec2 u_globe_center;
+          uniform vec3 u_camera_angles;
+
+          const float PI = 3.141592653589793;
+
+          void main() {
+            vec3 ray_dir = normalize(view_direction);
+            vec3 rotated = ray_dir;
+
+            // Apply camera rotations – pitch
+            float cosPitch = cos(u_camera_angles.x);
+            float sinPitch = sin(u_camera_angles.x);
+            rotated = vec3(
+              rotated.x,
+              rotated.y * cosPitch - rotated.z * sinPitch,
+              rotated.y * sinPitch + rotated.z * cosPitch
+            );
+
+            // bearing
+            float cosBearing = cos(u_camera_angles.y);
+            float sinBearing = sin(u_camera_angles.y);
+            rotated = vec3(
+              rotated.x * cosBearing - rotated.z * sinBearing,
+              rotated.y,
+              rotated.x * sinBearing + rotated.z * cosBearing
+            );
+
+            // roll
+            float cosRoll = cos(u_camera_angles.z);
+            float sinRoll = sin(u_camera_angles.z);
+            rotated = vec3(
+              rotated.x * cosRoll - rotated.y * sinRoll,
+              rotated.x * sinRoll + rotated.y * cosRoll,
+              rotated.z
+            );
+
+            // Apply globe rotation – latitude
+            float cosLat = cos(u_globe_center.y);
+            float sinLat = sin(u_globe_center.y);
+            rotated = vec3(
+              rotated.x,
+              rotated.y * cosLat + rotated.z * sinLat,
+              -rotated.y * sinLat + rotated.z * cosLat
+            );
+
+            // longitude
+            float cosLng = cos(u_globe_center.x);
+            float sinLng = sin(u_globe_center.x);
+            rotated = vec3(
+              rotated.x * cosLng + rotated.z * sinLng,
+              rotated.y,
+              -rotated.x * sinLng + rotated.z * cosLng
+            );
+
+            // Convert to spherical coordinates
+            float lng = atan(rotated.x, rotated.z);
+            float lat = asin(rotated.y);
+
+            vec2 uv = vec2(
+              (lng / PI) * 0.5 + 0.5,
+              (lat / (PI * 0.5)) * 0.5 + 0.5
+            );
+
+            // Create star field via hashed grid
+            vec2 scaledUV = uv * 200.0;
+            vec2 gridPos = floor(scaledUV);
+            float hash = fract(sin(dot(gridPos, vec2(12.9898, 78.233))) * 43758.5453);
+
+            float stars = 0.0;
+            if (hash > ${(1 - density).toFixed(2)}) {
+              float hashX = fract(sin(dot(gridPos, vec2(127.1, 311.7))) * 43758.5453);
+              float hashY = fract(sin(dot(gridPos, vec2(269.5, 183.3))) * 43758.5453);
+              vec2 randomOffset = vec2(hashX, hashY);
+              vec2 localPos = fract(scaledUV);
+              vec2 delta = (localPos - randomOffset);
+
+              // Correct for equirectangular projection distortion so stars
+              // are circular at every latitude.
+              // Grid cells span (2π/gridSize) in longitude but only
+              // (π/gridSize) in latitude — twice as wide angularly.
+              // Scaling delta.x by 2 makes a unit step in x represent
+              // the same angular distance as a unit step in y.
+              // cos(lat) further corrects for meridian convergence at poles.
+              float aspect = 2.0 * max(0.1, cos(lat));
+              delta.x *= aspect;
+
+              float dist = length(delta);
+              float sizeHash = fract(sin(dot(gridPos, vec2(415.2, 371.9))) * 43758.5453);
+              float starSize = 0.05 + 0.1 * sizeHash;
+
+              stars = 1.0 - smoothstep(0.0, starSize, dist);
+              stars = pow(stars, 4.0);
+
+              float brightness = 0.5 + 0.5 * sizeHash;
+              stars *= brightness;
+            }
+
+            stars *= u_stars_intensity;
+            vec3 starColor = vec3(1.0) * stars;
+
+            gl_FragColor = vec4(starColor, 1.0);
+          }
+        `;
+
+        // ── Compile shaders ───────────────────────────────────────
+        const vertexShader = gl.createShader(gl.VERTEX_SHADER)!;
+        gl.shaderSource(vertexShader, vertexSource);
+        gl.compileShader(vertexShader);
+        if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
+          console.error('Stars vertex shader error:', gl.getShaderInfoLog(vertexShader));
+          return;
+        }
+
+        const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER)!;
+        gl.shaderSource(fragmentShader, fragmentSource);
+        gl.compileShader(fragmentShader);
+        if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
+          console.error('Stars fragment shader error:', gl.getShaderInfoLog(fragmentShader));
+          return;
+        }
+
+        // ── Link program ──────────────────────────────────────────
+        program = gl.createProgram()!;
+        gl.attachShader(program, vertexShader);
+        gl.attachShader(program, fragmentShader);
+        gl.linkProgram(program);
+        if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+          console.error('Stars program link error:', gl.getProgramInfoLog(program));
+          program = null;
+          return;
+        }
+
+        // ── Full-screen quad ──────────────────────────────────────
+        const vertices = new Float32Array([
+          -1, -1,
+           1, -1,
+           1,  1,
+          -1,  1
+        ]);
+        const indices = new Uint16Array([0, 1, 2, 0, 2, 3]);
+
+        vertexBuffer = gl.createBuffer()!;
+        gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
+
+        indexBuffer = gl.createBuffer()!;
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+
+        aPos = gl.getAttribLocation(program, 'a_pos');
+      } catch (e) {
+        console.warn('Stars layer onAdd failed:', e);
+        program = null; // ensure render is a no-op
+      }
+    },
+
+    render: function (gl: WebGLRenderingContext, _matrix: number[]) {
+      if (!layerMap || !program || !vertexBuffer || !indexBuffer) return;
+
+      try {
+        const transform = (layerMap as any).transform;
+        if (!transform || !transform.inverseProjectionMatrix) return;
+
+        // Only render in globe projection — guard against missing API
+        if (typeof transform.getProjectionData === 'function') {
+          const projectionData = transform.getProjectionData({
+            overscaledTileID: null,
+            applyGlobeMatrix: true,
+            applyTerrainMatrix: true,
+          });
+          if (projectionData.projectionTransition === 0) return;
+        }
+
+        gl.useProgram(program);
+
+        // ── Compute globe position via inverse projection ─────────
+        const globePosition = [0, 0, 0];
+
+        const circumference = transform.worldSize;
+        const globeRadius =
+          (circumference / (2 * Math.PI)) *
+          Math.cos((transform.center.lat * Math.PI) / 180);
+
+        const globeCenter = [
+          (transform.center.lng * Math.PI) / 180.0,
+          (transform.center.lat * Math.PI) / 180.0,
+        ];
+
+        const cameraAngles = [
+          transform.pitchInRadians != null
+            ? transform.pitchInRadians
+            : (transform.pitch * Math.PI) / 180,
+          -(transform.bearingInRadians != null
+            ? transform.bearingInRadians
+            : (transform.bearing * Math.PI) / 180),
+          -(transform.rollInRadians || 0),
+        ];
+
+        // ── Set uniforms ──────────────────────────────────────────
+        gl.uniformMatrix4fv(
+          gl.getUniformLocation(program, 'u_inv_proj_matrix'),
+          false,
+          transform.inverseProjectionMatrix
+        );
+        gl.uniform3fv(
+          gl.getUniformLocation(program, 'u_globe_position'),
+          globePosition
+        );
+        gl.uniform1f(
+          gl.getUniformLocation(program, 'u_globe_radius'),
+          globeRadius
+        );
+        gl.uniform1f(
+          gl.getUniformLocation(program, 'u_stars_intensity'),
+          intensity
+        );
+        gl.uniform2fv(
+          gl.getUniformLocation(program, 'u_globe_center'),
+          globeCenter
+        );
+        gl.uniform3fv(
+          gl.getUniformLocation(program, 'u_camera_angles'),
+          cameraAngles
+        );
+
+        // ── Draw ──────────────────────────────────────────────────
+        gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+        gl.enableVertexAttribArray(aPos);
+        gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0);
+
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+
+        gl.disable(gl.DEPTH_TEST);
+        gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0);
+        gl.enable(gl.DEPTH_TEST);
+      } catch (e) {
+        // Silently ignore – stars are cosmetic, don't break the map
+      }
+    },
+  };
+}

--- a/App/frontend/src/starsLayer.ts
+++ b/App/frontend/src/starsLayer.ts
@@ -1,8 +1,5 @@
 ﻿/**
- * MapLibre GL JS Stars Custom Layer (TypeScript)
- *
- * Adds a procedural starry background to globe projection views using a custom layer.
- * Stars are generated in a fragment shader and properly rotate with the globe camera.
+ * Heavily based on https://github.com/birkskyum/maplibre-gl-stars/tree/main
  */
 
 export interface StarsLayerOptions {

--- a/App/frontend/src/types/maplibre-gl-augmentations.d.ts
+++ b/App/frontend/src/types/maplibre-gl-augmentations.d.ts
@@ -4,5 +4,23 @@ import type * as MaplibreGL from 'maplibre-gl';
 declare module 'maplibre-gl' {
   export interface Map {
     setProjection(projection: { type: string }): void;
+    transform: MapTransform;
+  }
+
+  export interface MapTransform {
+    modelViewProjectionMatrix: Float64Array;
+    inverseProjectionMatrix: Float64Array;
+    worldSize: number;
+    center: { lng: number; lat: number };
+    pitch: number;
+    bearing: number;
+    pitchInRadians?: number;
+    bearingInRadians?: number;
+    rollInRadians?: number;
+    getProjectionData(options: {
+      overscaledTileID: null;
+      applyGlobeMatrix: boolean;
+      applyTerrainMatrix: boolean;
+    }): { projectionTransition: number };
   }
 }

--- a/App/frontend/tsconfig.json
+++ b/App/frontend/tsconfig.json
@@ -1,7 +1,7 @@
 ﻿{
   "compilerOptions": {
     "target": "es6",
-    "module": "es6",
+    "module": "es2020",
     "moduleResolution": "node",
     "strict": true,
     "esModuleInterop": true,

--- a/App/static/style/mapstyle.json
+++ b/App/static/style/mapstyle.json
@@ -1,0 +1,2977 @@
+﻿{
+  "version": 8,
+  "sources": {
+    "ne2_shaded": {
+      "maxzoom": 6,
+      "tileSize": 256,
+      "tiles": [
+        "https://tiles.openfreemap.org/natural_earth/ne2sr/{z}/{x}/{y}.png"
+      ],
+      "type": "raster"
+    },
+    "openmaptiles": {
+      "type": "vector",
+      "url": "https://tiles.openfreemap.org/planet"
+    }
+  },
+  "sprite": "https://tiles.openfreemap.org/sprites/ofm_f384/ofm",
+  "glyphs": "https://tiles.openfreemap.org/fonts/{fontstack}/{range}.pbf",
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "rgb(242,243,240)"
+      }
+    },
+    {
+      "id": "park",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "park",
+      "filter": [
+        "match",
+        [
+          "geometry-type"
+        ],
+        [
+          "MultiPolygon",
+          "Polygon"
+        ],
+        true, false],
+      "paint": {
+        "fill-color": "rgb(230, 233, 229)"
+      }
+    },
+    {
+      "id": "water",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "water",
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "MultiPolygon",
+            "Polygon"
+          ],
+          true, false],
+        [
+          "!=",
+          [
+            "get",
+            "brunnel"
+          ],
+          "tunnel"
+        ]
+      ],
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "rgb(194, 200, 202)"
+      }
+    },
+    {
+      "id": "landcover_ice_shelf",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "maxzoom": 8,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "MultiPolygon",
+            "Polygon"
+          ],
+          true, false],
+        [
+          "==",
+          [
+            "get",
+            "subclass"
+          ],
+          "ice_shelf"
+        ]
+      ],
+      "paint": {
+        "fill-color": "hsl(0,0%,98%)",
+        "fill-opacity": 0.7
+      }
+    },
+    {
+      "id": "landcover_glacier",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "maxzoom": 8,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "MultiPolygon",
+            "Polygon"
+          ],
+          true, false],
+        [
+          "==",
+          [
+            "get",
+            "subclass"
+          ],
+          "glacier"
+        ]
+      ],
+      "paint": {
+        "fill-color": "hsl(0,0%,98%)",
+        "fill-opacity": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          0, 1, 8, 0.5]
+      }
+    },
+    {
+      "id": "landuse_residential",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "maxzoom": 16,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "MultiPolygon",
+            "Polygon"
+          ],
+          true, false],
+        [
+          "==",
+          [
+            "get",
+            "class"
+          ],
+          "residential"
+        ]
+      ],
+      "paint": {
+        "fill-color": "rgb(234, 234, 230)",
+        "fill-opacity": [
+          "interpolate",
+          [
+            "exponential",
+            0.6],
+          [
+            "zoom"
+          ],
+          8, 0.8, 9, 0.6]
+      }
+    },
+    {
+      "id": "landcover_wood",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "minzoom": 10,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "MultiPolygon",
+            "Polygon"
+          ],
+          true, false],
+        [
+          "==",
+          [
+            "get",
+            "class"
+          ],
+          "wood"
+        ]
+      ],
+      "paint": {
+        "fill-color": "rgb(220,224,220)",
+        "fill-opacity": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8, 0, 12, 1]
+      }
+    },
+    {
+      "id": "waterway",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "match",
+        [
+          "geometry-type"
+        ],
+        [
+          "LineString",
+          "MultiLineString"
+        ],
+        true, false],
+      "paint": {
+        "line-color": "hsl(195,17%,78%)"
+      }
+    },
+    {
+      "id": "building",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "building",
+      "minzoom": 12,
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "rgb(234, 234, 229)",
+        "fill-outline-color": "rgb(219, 219, 218)"
+      }
+    },
+    {
+      "id": "tunnel_motorway_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "all",
+          [
+            "==",
+            [
+              "get",
+              "brunnel"
+            ],
+            "tunnel"
+          ],
+          [
+            "==",
+            [
+              "get",
+              "class"
+            ],
+            "motorway"
+          ]
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "rgb(213, 213, 213)",
+        "line-opacity": 1,
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.4],
+          [
+            "zoom"
+          ],
+          5.8, 0, 6, 3, 20, 40]
+      }
+    },
+    {
+      "id": "tunnel_motorway_inner",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "all",
+          [
+            "==",
+            [
+              "get",
+              "brunnel"
+            ],
+            "tunnel"
+          ],
+          [
+            "==",
+            [
+              "get",
+              "class"
+            ],
+            "motorway"
+          ]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "rgb(234,234,234)",
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.4],
+          [
+            "zoom"
+          ],
+          4, 2, 6, 1.3, 20, 30]
+      }
+    },
+    {
+      "id": "aeroway-taxiway",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 12,
+      "filter": [
+        "match",
+        [
+          "get",
+          "class"
+        ],
+        [
+          "taxiway"
+        ],
+        true, false],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,88%)",
+        "line-opacity": 1,
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.55],
+          [
+            "zoom"
+          ],
+          13, 1.8, 20, 20]
+      }
+    },
+    {
+      "id": "aeroway-runway-casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "filter": [
+        "match",
+        [
+          "get",
+          "class"
+        ],
+        [
+          "runway"
+        ],
+        true, false],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,88%)",
+        "line-opacity": 1,
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.5],
+          [
+            "zoom"
+          ],
+          11, 6, 17, 55]
+      }
+    },
+    {
+      "id": "aeroway-area",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "MultiPolygon",
+            "Polygon"
+          ],
+          true, false],
+        [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "runway",
+            "taxiway"
+          ],
+          true, false]
+      ],
+      "paint": {
+        "fill-color": "rgba(255, 255, 255, 1)",
+        "fill-opacity": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          13, 0, 14, 1]
+      }
+    },
+    {
+      "id": "aeroway-runway",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "runway"
+          ],
+          true, false],
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-opacity": 1,
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.5],
+          [
+            "zoom"
+          ],
+          11, 4, 17, 50]
+      }
+    },
+    {
+      "id": "road_area_pier",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "MultiPolygon",
+            "Polygon"
+          ],
+          true, false],
+        [
+          "==",
+          [
+            "get",
+            "class"
+          ],
+          "pier"
+        ]
+      ],
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "rgb(242,243,240)"
+      }
+    },
+    {
+      "id": "road_pier",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "pier"
+          ],
+          true, false]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "rgb(242,243,240)",
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.2],
+          [
+            "zoom"
+          ],
+          15, 1, 17, 4]
+      }
+    },
+    {
+      "id": "highway_path",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "==",
+          [
+            "get",
+            "class"
+          ],
+          "path"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "rgb(234, 234, 234)",
+        "line-opacity": 0.9,
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.2],
+          [
+            "zoom"
+          ],
+          13, 1, 20, 10]
+      }
+    },
+    {
+      "id": "highway_minor",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "minor",
+            "service",
+            "track"
+          ],
+          true, false]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,88%)",
+        "line-opacity": 0.9,
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.55],
+          [
+            "zoom"
+          ],
+          13, 1.8, 20, 20]
+      }
+    },
+    {
+      "id": "highway_major_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "primary",
+            "secondary",
+            "tertiary",
+            "trunk"
+          ],
+          true, false]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "rgb(213, 213, 213)",
+        "line-dasharray": [12, 0],
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.3],
+          [
+            "zoom"
+          ],
+          10, 3, 20, 23]
+      }
+    },
+    {
+      "id": "highway_major_inner",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "primary",
+            "secondary",
+            "tertiary",
+            "trunk"
+          ],
+          true, false]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.3],
+          [
+            "zoom"
+          ],
+          10, 2, 20, 20]
+      }
+    },
+    {
+      "id": "highway_major_subtle",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "maxzoom": 11,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "primary",
+            "secondary",
+            "tertiary",
+            "trunk"
+          ],
+          true, false]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "hsla(0,0%,85%,0.69)",
+        "line-width": 2
+      }
+    },
+    {
+      "id": "highway_motorway_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "all",
+          [
+            "match",
+            [
+              "get",
+              "brunnel"
+            ],
+            [
+              "bridge",
+              "tunnel"
+            ],
+            false, true],
+          [
+            "==",
+            [
+              "get",
+              "class"
+            ],
+            "motorway"
+          ]
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "rgb(213, 213, 213)",
+        "line-dasharray": [2, 0],
+        "line-opacity": 1,
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.4],
+          [
+            "zoom"
+          ],
+          5.8, 0, 6, 3, 20, 40]
+      }
+    },
+    {
+      "id": "highway_motorway_inner",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "all",
+          [
+            "match",
+            [
+              "get",
+              "brunnel"
+            ],
+            [
+              "bridge",
+              "tunnel"
+            ],
+            false, true],
+          [
+            "==",
+            [
+              "get",
+              "class"
+            ],
+            "motorway"
+          ]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          5.8, "hsla(0,0%,85%,0.53)",
+          6, "#fff"
+        ],
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.4],
+          [
+            "zoom"
+          ],
+          4, 2, 6, 1.3, 20, 30]
+      }
+    },
+    {
+      "id": "highway_motorway_subtle",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "maxzoom": 6,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "==",
+          [
+            "get",
+            "class"
+          ],
+          "motorway"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "hsla(0,0%,85%,0.53)",
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.4],
+          [
+            "zoom"
+          ],
+          4, 2, 6, 1.3]
+      }
+    },
+    {
+      "id": "railway_transit",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "all",
+          [
+            "==",
+            [
+              "get",
+              "class"
+            ],
+            "transit"
+          ],
+          [
+            "match",
+            [
+              "get",
+              "brunnel"
+            ],
+            [
+              "tunnel"
+            ],
+            false, true]
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#dddddd",
+        "line-width": 3
+      }
+    },
+    {
+      "id": "railway_transit_dashline",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "all",
+          [
+            "==",
+            [
+              "get",
+              "class"
+            ],
+            "transit"
+          ],
+          [
+            "match",
+            [
+              "get",
+              "brunnel"
+            ],
+            [
+              "tunnel"
+            ],
+            false, true]
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fafafa",
+        "line-dasharray": [3, 3],
+        "line-width": 2
+      }
+    },
+    {
+      "id": "railway_service",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "all",
+          [
+            "==",
+            [
+              "get",
+              "class"
+            ],
+            "rail"
+          ],
+          [
+            "has",
+            "service"
+          ]
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#dddddd",
+        "line-width": 3
+      }
+    },
+    {
+      "id": "railway_service_dashline",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "==",
+          [
+            "get",
+            "class"
+          ],
+          "rail"
+        ],
+        [
+          "has",
+          "service"
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fafafa",
+        "line-dasharray": [3, 3],
+        "line-width": 2
+      }
+    },
+    {
+      "id": "railway",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "all",
+          [
+            "!",
+            [
+              "has",
+              "service"
+            ]
+          ],
+          [
+            "==",
+            [
+              "get",
+              "class"
+            ],
+            "rail"
+          ]
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#dddddd",
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.3],
+          [
+            "zoom"
+          ],
+          16, 3, 20, 7]
+      }
+    },
+    {
+      "id": "railway_dashline",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "all",
+          [
+            "!",
+            [
+              "has",
+              "service"
+            ]
+          ],
+          [
+            "==",
+            [
+              "get",
+              "class"
+            ],
+            "rail"
+          ]
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fafafa",
+        "line-dasharray": [3, 3],
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.3],
+          [
+            "zoom"
+          ],
+          16, 2, 20, 6]
+      }
+    },
+    {
+      "id": "highway_motorway_bridge_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "all",
+          [
+            "==",
+            [
+              "get",
+              "brunnel"
+            ],
+            "bridge"
+          ],
+          [
+            "==",
+            [
+              "get",
+              "class"
+            ],
+            "motorway"
+          ]
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "rgb(213, 213, 213)",
+        "line-dasharray": [2, 0],
+        "line-opacity": 1,
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.4],
+          [
+            "zoom"
+          ],
+          5.8, 0, 6, 5, 20, 45]
+      }
+    },
+    {
+      "id": "highway_motorway_bridge_inner",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "all",
+          [
+            "==",
+            [
+              "get",
+              "brunnel"
+            ],
+            "bridge"
+          ],
+          [
+            "==",
+            [
+              "get",
+              "class"
+            ],
+            "motorway"
+          ]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          5.8, "hsla(0,0%,85%,0.53)",
+          6, "#fff"
+        ],
+        "line-width": [
+          "interpolate",
+          [
+            "exponential",
+            1.4],
+          [
+            "zoom"
+          ],
+          4, 2, 6, 1.3, 20, 30]
+      }
+    },
+    {
+      "id": "boundary_3",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        [
+          "\u003E=",
+          [
+            "get",
+            "admin_level"
+          ],
+          3],
+        [
+          "\u003C=",
+          [
+            "get",
+            "admin_level"
+          ],
+          6],
+        [
+          "!=",
+          [
+            "get",
+            "maritime"
+          ],
+          1],
+        [
+          "!=",
+          [
+            "get",
+            "disputed"
+          ],
+          1],
+        [
+          "!",
+          [
+            "has",
+            "claimed_by"
+          ]
+        ]
+      ],
+      "paint": {
+        "line-color": "hsl(0,0%,70%)",
+        "line-dasharray": [1, 1],
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            1],
+          [
+            "zoom"
+          ],
+          7, 1, 11, 2]
+      }
+    },
+    {
+      "id": "boundary_2",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "get",
+            "admin_level"
+          ],
+          2],
+        [
+          "!=",
+          [
+            "get",
+            "maritime"
+          ],
+          1],
+        [
+          "!=",
+          [
+            "get",
+            "disputed"
+          ],
+          1],
+        [
+          "!",
+          [
+            "has",
+            "claimed_by"
+          ]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,70%)",
+        "line-opacity": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          0, 0.4, 4, 1],
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          3, 1, 5, 1.2, 12, 3]
+      }
+    },
+    {
+      "id": "boundary_disputed",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "filter": [
+        "all",
+        [
+          "!=",
+          [
+            "get",
+            "maritime"
+          ],
+          1],
+        [
+          "==",
+          [
+            "get",
+            "disputed"
+          ],
+          1]
+      ],
+      "paint": {
+        "line-color": "hsl(0,0%,70%)",
+        "line-dasharray": [1, 2],
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          3, 1, 5, 1.2, 12, 3]
+      }
+    },
+    {
+      "id": "waterway_line_label",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "minzoom": 10,
+      "filter": [
+        "match",
+        [
+          "geometry-type"
+        ],
+        [
+          "LineString",
+          "MultiLineString"
+        ],
+        true, false],
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 350,
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            " ",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-size": 14
+      },
+      "paint": {
+        "text-color": "hsl(0,0%,66%)",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "water_name_point_label",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "water_name",
+      "filter": [
+        "match",
+        [
+          "geometry-type"
+        ],
+        [
+          "MultiPoint",
+          "Point"
+        ],
+        true, false],
+      "layout": {
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            "\n",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          0, 10, 8, 14]
+      },
+      "paint": {
+        "text-color": "#495e91",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "water_name_line_label",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "water_name",
+      "filter": [
+        "match",
+        [
+          "geometry-type"
+        ],
+        [
+          "LineString",
+          "MultiLineString"
+        ],
+        true, false],
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 350,
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            " ",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-size": 14
+      },
+      "paint": {
+        "text-color": "#495e91",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "highway-name-path",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 15.5,
+      "filter": [
+        "==",
+        [
+          "get",
+          "class"
+        ],
+        "path"
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            " ",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-rotation-alignment": "map",
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          13, 12, 14, 13]
+      },
+      "paint": {
+        "text-color": "hsl(30,0%,62%)",
+        "text-halo-color": "#f8f4f0",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "highway-name-minor",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "minor",
+            "service",
+            "track"
+          ],
+          true, false]
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            " ",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-rotation-alignment": "map",
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          13, 12, 14, 13]
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "highway-name-major",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 12.2,
+      "filter": [
+        "match",
+        [
+          "get",
+          "class"
+        ],
+        [
+          "primary",
+          "secondary",
+          "tertiary",
+          "trunk"
+        ],
+        true, false],
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            " ",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-rotation-alignment": "map",
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          13, 12, 14, 13]
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "highway-shield-non-us",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "\u003C=",
+          [
+            "get",
+            "ref_length"
+          ],
+          6],
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "match",
+          [
+            "get",
+            "network"
+          ],
+          [
+            "us-highway",
+            "us-interstate",
+            "us-state"
+          ],
+          false, true]
+      ],
+      "layout": {
+        "icon-image": [
+          "concat",
+          "road_",
+          [
+            "get",
+            "ref_length"
+          ]
+        ],
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-placement": [
+          "step",
+          [
+            "zoom"
+          ],
+          "point",
+          11, "line"
+        ],
+        "symbol-spacing": 200,
+        "text-field": [
+          "to-string",
+          [
+            "get",
+            "ref"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 10
+      }
+    },
+    {
+      "id": "highway-shield-us-interstate",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "\u003C=",
+          [
+            "get",
+            "ref_length"
+          ],
+          6],
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "match",
+          [
+            "get",
+            "network"
+          ],
+          [
+            "us-interstate"
+          ],
+          true, false]
+      ],
+      "layout": {
+        "icon-image": [
+          "concat",
+          [
+            "get",
+            "network"
+          ],
+          "_",
+          [
+            "get",
+            "ref_length"
+          ]
+        ],
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-placement": [
+          "step",
+          [
+            "zoom"
+          ],
+          "point",
+          7, "line",
+          8, "line"
+        ],
+        "symbol-spacing": 200,
+        "text-field": [
+          "to-string",
+          [
+            "get",
+            "ref"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 10
+      }
+    },
+    {
+      "id": "road_shield_us",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [
+          "\u003C=",
+          [
+            "get",
+            "ref_length"
+          ],
+          6],
+        [
+          "match",
+          [
+            "geometry-type"
+          ],
+          [
+            "LineString",
+            "MultiLineString"
+          ],
+          true, false],
+        [
+          "match",
+          [
+            "get",
+            "network"
+          ],
+          [
+            "us-highway",
+            "us-state"
+          ],
+          true, false]
+      ],
+      "layout": {
+        "icon-image": [
+          "concat",
+          [
+            "get",
+            "network"
+          ],
+          "_",
+          [
+            "get",
+            "ref_length"
+          ]
+        ],
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-placement": [
+          "step",
+          [
+            "zoom"
+          ],
+          "point",
+          11, "line"
+        ],
+        "symbol-spacing": 200,
+        "text-field": [
+          "to-string",
+          [
+            "get",
+            "ref"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 10
+      }
+    },
+    {
+      "id": "airport",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "aerodrome_label",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "has",
+          "iata"
+        ]
+      ],
+      "layout": {
+        "icon-image": "airport_11",
+        "icon-size": 1,
+        "text-anchor": "top",
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            "\n",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": 12
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "label_other",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "minzoom": 8,
+      "filter": [
+        "match",
+        [
+          "get",
+          "class"
+        ],
+        [
+          "city",
+          "continent",
+          "country",
+          "state",
+          "town",
+          "village"
+        ],
+        false, true],
+      "layout": {
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            "\n",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 9,
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8, 9, 12, 10],
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#333",
+        "text-halo-blur": 1,
+        "text-halo-color": "#fff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "label_village",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "minzoom": 9,
+      "filter": [
+        "==",
+        [
+          "get",
+          "class"
+        ],
+        "village"
+      ],
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-image": [
+          "step",
+          [
+            "zoom"
+          ],
+          "circle_11_black",
+          10, ""
+        ],
+        "icon-optional": false,
+        "icon-size": 0.2,
+        "text-anchor": "bottom",
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            "\n",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-size": [
+          "interpolate",
+          [
+            "exponential",
+            1.2],
+          [
+            "zoom"
+          ],
+          7, 10, 11, 12]
+      },
+      "paint": {
+        "text-color": "#000",
+        "text-halo-blur": 1,
+        "text-halo-color": "#fff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "label_town",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "minzoom": 6,
+      "filter": [
+        "==",
+        [
+          "get",
+          "class"
+        ],
+        "town"
+      ],
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-image": [
+          "step",
+          [
+            "zoom"
+          ],
+          "circle_11_black",
+          10, ""
+        ],
+        "icon-optional": false,
+        "icon-size": 0.2,
+        "text-anchor": "bottom",
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            "\n",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-size": [
+          "interpolate",
+          [
+            "exponential",
+            1.2],
+          [
+            "zoom"
+          ],
+          7, 12, 11, 14]
+      },
+      "paint": {
+        "text-color": "#000",
+        "text-halo-blur": 1,
+        "text-halo-color": "#fff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "label_state",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "minzoom": 5,
+      "maxzoom": 8,
+      "filter": [
+        "==",
+        [
+          "get",
+          "class"
+        ],
+        "state"
+      ],
+      "layout": {
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            "\n",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 9,
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          5, 10, 8, 14],
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#333",
+        "text-halo-blur": 1,
+        "text-halo-color": "#fff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "label_city",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "minzoom": 3,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "get",
+            "class"
+          ],
+          "city"
+        ],
+        [
+          "!=",
+          [
+            "get",
+            "capital"
+          ],
+          2]
+      ],
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-image": [
+          "step",
+          [
+            "zoom"
+          ],
+          "circle_11_black",
+          9, ""
+        ],
+        "icon-optional": false,
+        "icon-size": 0.4,
+        "text-anchor": "bottom",
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            "\n",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [0, -0.1],
+        "text-size": [
+          "interpolate",
+          [
+            "exponential",
+            1.2],
+          [
+            "zoom"
+          ],
+          4, 11, 7, 13, 11, 18]
+      },
+      "paint": {
+        "text-color": "#000",
+        "text-halo-blur": 1,
+        "text-halo-color": "#fff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "label_city_capital",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "minzoom": 3,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "get",
+            "class"
+          ],
+          "city"
+        ],
+        [
+          "==",
+          [
+            "get",
+            "capital"
+          ],
+          2]
+      ],
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-image": [
+          "step",
+          [
+            "zoom"
+          ],
+          "circle_11_black",
+          9, ""
+        ],
+        "icon-optional": false,
+        "icon-size": 0.5,
+        "text-anchor": "bottom",
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            "\n",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Bold"
+        ],
+        "text-max-width": 8,
+        "text-offset": [0, -0.2],
+        "text-size": [
+          "interpolate",
+          [
+            "exponential",
+            1.2],
+          [
+            "zoom"
+          ],
+          4, 12, 7, 14, 11, 20]
+      },
+      "paint": {
+        "text-color": "#000",
+        "text-halo-blur": 1,
+        "text-halo-color": "#fff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "label_country_3",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "minzoom": 2,
+      "maxzoom": 9,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "get",
+            "class"
+          ],
+          "country"
+        ],
+        [
+          "\u003E=",
+          [
+            "get",
+            "rank"
+          ],
+          3]
+      ],
+      "layout": {
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            "\n",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Bold"
+        ],
+        "text-max-width": 6.25,
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          3, 9, 7, 17]
+      },
+      "paint": {
+        "text-color": "#000",
+        "text-halo-blur": 1,
+        "text-halo-color": "#fff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "label_country_2",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 9,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "get",
+            "class"
+          ],
+          "country"
+        ],
+        [
+          "==",
+          [
+            "get",
+            "rank"
+          ],
+          2]
+      ],
+      "layout": {
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            "\n",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Bold"
+        ],
+        "text-max-width": 6.25,
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          2, 9, 5, 17]
+      },
+      "paint": {
+        "text-color": "#000",
+        "text-halo-blur": 1,
+        "text-halo-color": "#fff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "label_country_1",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 9,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "get",
+            "class"
+          ],
+          "country"
+        ],
+        [
+          "==",
+          [
+            "get",
+            "rank"
+          ],
+          1]
+      ],
+      "layout": {
+        "text-field": [
+          "case",
+          [
+            "has",
+            "name:nonlatin"
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "name:latin"
+            ],
+            "\n",
+            [
+              "get",
+              "name:nonlatin"
+            ]
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "name_en"
+            ],
+            [
+              "get",
+              "name"
+            ]
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Bold"
+        ],
+        "text-max-width": 6.25,
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          1, 9, 4, 17]
+      },
+      "paint": {
+        "text-color": "#000",
+        "text-halo-blur": 1,
+        "text-halo-color": "#fff",
+        "text-halo-width": 1
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request updates the `maplibre-gl` dependency and related packages in the frontend, and modifies the map initialization logic in `main.ts` to use a local style file and simplifies projection setup. The main focus is on upgrading the mapping library and ensuring compatibility with its new version.

**Dependency and Compatibility Updates:**

* Upgraded `maplibre-gl` from version `2.4.0` to `4.7.1` in both `package.json` and `package-lock.json`, along with updates to its dependencies such as `earcut`, `geojson-vt`, `supercluster`, `kdbush`, `potpack`, `quickselect`, `tinyqueue`, and others. Several new type and utility dependencies were added to support the new version. [[1]](diffhunk://#diff-18c2e0dd9c5cb512d280fd82f13266a909ef34f02f8156b76431933ae788878bL11-R11) [[2]](diffhunk://#diff-18c2e0dd9c5cb512d280fd82f13266a909ef34f02f8156b76431933ae788878bL38-L43) [[3]](diffhunk://#diff-18c2e0dd9c5cb512d280fd82f13266a909ef34f02f8156b76431933ae788878bR74-R114) [[4]](diffhunk://#diff-18c2e0dd9c5cb512d280fd82f13266a909ef34f02f8156b76431933ae788878bL109-R156) [[5]](diffhunk://#diff-18c2e0dd9c5cb512d280fd82f13266a909ef34f02f8156b76431933ae788878bL146-R188) [[6]](diffhunk://#diff-18c2e0dd9c5cb512d280fd82f13266a909ef34f02f8156b76431933ae788878bL180-R238) [[7]](diffhunk://#diff-18c2e0dd9c5cb512d280fd82f13266a909ef34f02f8156b76431933ae788878bL207-R288) [[8]](diffhunk://#diff-18c2e0dd9c5cb512d280fd82f13266a909ef34f02f8156b76431933ae788878bL268-R322) [[9]](diffhunk://#diff-18c2e0dd9c5cb512d280fd82f13266a909ef34f02f8156b76431933ae788878bL280-R334) [[10]](diffhunk://#diff-18c2e0dd9c5cb512d280fd82f13266a909ef34f02f8156b76431933ae788878bR346-R364) [[11]](diffhunk://#diff-18c2e0dd9c5cb512d280fd82f13266a909ef34f02f8156b76431933ae788878bL335-R404) [[12]](diffhunk://#diff-6639539901a224e27a6416b51e6135f13b0b2ee37cab30816dc324d443102db5L10-R10)

**Map Initialization and Style Changes:**

* Changed the map style source in `main.ts` from a remote URL to a local file (`../static/style/mapstyle.json`) to allow for local development and customization.
* Removed the explicit call to `map.setProjection({ type: 'globe' })` on style load, likely due to changes in how projections are handled in the new `maplibre-gl` version.

**TypeScript and Import Adjustments:**

* Updated imports from `maplibre-gl` in `main.ts` to include additional types (`AddLayerObject`, `LayerSpecification`, `PropertyValueSpecification`) that may be needed for future development or compatibility with the updated library.

These changes modernize the mapping stack, improve maintainability, and set the stage for further frontend mapping features.