### PR TITLE
Important/middleearth

### DIFF
--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -6,6 +6,7 @@ import {
   LngLatLike,
   PropertyValueSpecification
 } from "maplibre-gl";
+import { registerKonamiCode } from './middleEarth.js';
 
 
 declare global {
@@ -30,6 +31,9 @@ if (!maplibregl) {
   });
 
   window.map = map;
+
+  // 🧙 Easter egg: type the Konami Code (↑↑↓↓←→←→BA) to enter Middle-earth mode
+  registerKonamiCode(map);
 
   const layersToggle = document.getElementById('layers-toggle');
   const layersMenu   = document.getElementById('layers-menu');

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -31,8 +31,6 @@ if (!maplibregl) {
   });
 
   window.map = map;
-
-  // 🧙 Easter egg: type the Konami Code (↑↑↓↓←→←→BA) to enter Middle-earth mode
   registerKonamiCode(map);
 
   const layersToggle = document.getElementById('layers-toggle');

--- a/App/frontend/src/middleEarth.ts
+++ b/App/frontend/src/middleEarth.ts
@@ -168,10 +168,7 @@ function onEscape(e: KeyboardEvent): void {
 /** The Konami Code sequence */
 const KONAMI = [
   'ArrowUp', 'ArrowUp',
-  'ArrowDown', 'ArrowDown',
-  'ArrowLeft', 'ArrowRight',
-  'ArrowLeft', 'ArrowRight',
-  'b', 'a',
+  'ArrowDown', 'ArrowDown'
 ];
 
 let konamiIndex = 0;

--- a/App/frontend/src/middleEarth.ts
+++ b/App/frontend/src/middleEarth.ts
@@ -1,0 +1,202 @@
+﻿/**
+ * 🧙 Middle-earth Easter Egg
+ *
+ * Activated via the Konami Code: ↑ ↑ ↓ ↓ ← → ← → B A
+ *
+ * Uses the publicly available ESRI Middle-earth vector tile service
+ * rendered via MapLibre GL JS.
+ */
+import type * as MaplibreGL from 'maplibre-gl';
+
+/** Middle-earth style using ESRI's public Middle-earth map tiles */
+const MIDDLE_EARTH_STYLE: string =
+  'https://raw.githubusercontent.com/jjrom/lotr-map/main/lotr_mapstyle.json';
+
+/** Fallback: a hand-crafted raster-based style pointing at ESRI's Middle-earth tile service */
+function buildMiddleEarthRasterStyle(): object {
+  return {
+    version: 8,
+    name: 'Middle-earth',
+    sources: {
+      'middle-earth': {
+        type: 'raster',
+        tiles: [
+          'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Middle_earth_Imagery/MapServer/tile/{z}/{y}/{x}',
+        ],
+        tileSize: 256,
+        attribution: '© Esri, Middle-earth',
+        minzoom: 0,
+        maxzoom: 10,
+      },
+    },
+    layers: [
+      {
+        id: 'middle-earth-tiles',
+        type: 'raster',
+        source: 'middle-earth',
+        minzoom: 0,
+        maxzoom: 22,
+      },
+    ],
+  };
+}
+
+let isActive = false;
+let savedStyle: string | object | null = null;
+let savedCenter: [number, number] | null = null;
+let savedZoom: number | null = null;
+let savedProjection: string | null = null;
+let banner: HTMLElement | null = null;
+
+/** Create and show the "You have found the One Map" banner */
+function showBanner(): void {
+  if (banner) return;
+  banner = document.createElement('div');
+  banner.id = 'me-banner';
+  banner.innerHTML = `
+    <div class="me-inner">
+      <div class="me-rune">💍</div>
+      <div class="me-title">ONE MAP TO RULE THEM ALL</div>
+      <div class="me-subtitle">Middle-earth mode activated — press <kbd>Esc</kbd> to return</div>
+    </div>`;
+  document.body.appendChild(banner);
+
+  // Auto-hide after 4 s
+  setTimeout(() => {
+    banner?.classList.add('me-fade-out');
+    setTimeout(() => { banner?.remove(); banner = null; }, 600);
+  }, 4000);
+}
+
+/** Remove the banner if still visible */
+function hideBanner(): void {
+  banner?.remove();
+  banner = null;
+}
+
+export function isMiddleEarthActive(): boolean {
+  return isActive;
+}
+
+/**
+ * Activate Middle-earth mode.
+ * Saves the current map state, then swaps in the ME style + flies to Middle-earth.
+ */
+export async function activateMiddleEarth(map: MaplibreGL.Map): Promise<void> {
+  if (isActive) return;
+  isActive = true;
+
+  // Save current state
+  const center = map.getCenter();
+  savedCenter = [center.lng, center.lat];
+  savedZoom = map.getZoom();
+  savedProjection = 'globe'; // default projection used by this app
+  savedStyle = map.getStyle();
+
+  showBanner();
+
+  // Swap style – try the community GeoJSON-based style first, fall back to ESRI raster
+  try {
+    await new Promise<void>((resolve, reject) => {
+      // Listen for style.load ONCE
+      const onLoaded = () => { map.off('style.load', onLoaded); resolve(); };
+      const onError = (e: any) => { map.off('error', onError); reject(e); };
+      map.once('style.load', onLoaded);
+      map.once('error', onError);
+      map.setStyle(MIDDLE_EARTH_STYLE);
+    });
+  } catch {
+    console.warn('[ME] Community style failed, falling back to ESRI raster tiles.');
+    await new Promise<void>((resolve) => {
+      map.once('style.load', () => resolve());
+      map.setStyle(buildMiddleEarthRasterStyle() as any);
+    });
+  }
+
+  // Turn off globe projection – Middle-earth is flat (like Tolkien intended)
+  try {
+    map.setProjection({ type: 'mercator' } as any);
+  } catch { /* projection API may not be available */ }
+
+  // Fly to the centre of Middle-earth (Rohan/Gondor region in the image)
+  map.flyTo({
+    center: [0, 0],    // The tile service is centred on 0,0 by design
+    zoom: 3,
+    duration: 2500,
+    easing: (t) => t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t,
+  });
+
+  // Listen for Escape key to deactivate
+  window.addEventListener('keydown', onEscape);
+}
+
+/**
+ * Deactivate Middle-earth mode and restore the previous map state.
+ */
+export async function deactivateMiddleEarth(map: MaplibreGL.Map): Promise<void> {
+  if (!isActive) return;
+  isActive = false;
+  hideBanner();
+  window.removeEventListener('keydown', onEscape);
+
+  if (!savedStyle) return;
+
+  await new Promise<void>((resolve) => {
+    map.once('style.load', () => resolve());
+    map.setStyle(savedStyle as any);
+  });
+
+  if (savedProjection) {
+    try { map.setProjection({ type: savedProjection } as any); } catch { /* ignore */ }
+  }
+
+  map.flyTo({
+    center: savedCenter ?? [10, 60],
+    zoom: savedZoom ?? 6,
+    duration: 2000,
+  });
+}
+
+let _mapRef: MaplibreGL.Map | null = null;
+
+function onEscape(e: KeyboardEvent): void {
+  if (e.key === 'Escape' && _mapRef) {
+    deactivateMiddleEarth(_mapRef);
+  }
+}
+
+/** The Konami Code sequence */
+const KONAMI = [
+  'ArrowUp', 'ArrowUp',
+  'ArrowDown', 'ArrowDown',
+  'ArrowLeft', 'ArrowRight',
+  'ArrowLeft', 'ArrowRight',
+  'b', 'a',
+];
+
+let konamiIndex = 0;
+
+/**
+ * Register the Konami Code listener on the document.
+ * Pass the map instance so it can be toggled when the code is entered.
+ */
+export function registerKonamiCode(map: MaplibreGL.Map): void {
+  _mapRef = map;
+  document.addEventListener('keydown', (e: KeyboardEvent) => {
+    const expected = KONAMI[konamiIndex];
+    if (e.key === expected) {
+      konamiIndex++;
+      if (konamiIndex === KONAMI.length) {
+        konamiIndex = 0;
+        if (isActive) {
+          deactivateMiddleEarth(map);
+        } else {
+          activateMiddleEarth(map);
+        }
+      }
+    } else {
+      // Partial reset – if first key matches, keep it
+      konamiIndex = e.key === KONAMI[0] ? 1 : 0;
+    }
+  });
+}

--- a/App/frontend/src/middleEarth.ts
+++ b/App/frontend/src/middleEarth.ts
@@ -1,54 +1,23 @@
 ﻿/**
- * 🧙 Middle-earth Easter Egg
- *
- * Activated via the Konami Code: ↑ ↑ ↓ ↓ ← → ← → B A
- *
- * Uses the publicly available ESRI Middle-earth vector tile service
- * rendered via MapLibre GL JS.
+ * Middle-earth Mode for Maplibre GL JS
+ * Konami Code: gandalf
  */
 import type * as MaplibreGL from 'maplibre-gl';
 
-/** Middle-earth style using ESRI's public Middle-earth map tiles */
-const MIDDLE_EARTH_STYLE: string =
-  'https://raw.githubusercontent.com/jjrom/lotr-map/main/lotr_mapstyle.json';
+const ME_SOURCE = 'middle-earth-source';
+const ME_LAYER  = 'middle-earth-layer';
+const ME_BG     = 'middle-earth-bg';
 
-/** Fallback: a hand-crafted raster-based style pointing at ESRI's Middle-earth tile service */
-function buildMiddleEarthRasterStyle(): object {
-  return {
-    version: 8,
-    name: 'Middle-earth',
-    sources: {
-      'middle-earth': {
-        type: 'raster',
-        tiles: [
-          'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Middle_earth_Imagery/MapServer/tile/{z}/{y}/{x}',
-        ],
-        tileSize: 256,
-        attribution: '© Esri, Middle-earth',
-        minzoom: 0,
-        maxzoom: 10,
-      },
-    },
-    layers: [
-      {
-        id: 'middle-earth-tiles',
-        type: 'raster',
-        source: 'middle-earth',
-        minzoom: 0,
-        maxzoom: 22,
-      },
-    ],
-  };
-}
+// ESRI Middle-earth tile service – note ESRI uses {z}/{y}/{x} row/col order
+const ME_TILE_URL =
+  'https://tiles.arcgis.com/tiles/CBiB2HwHGXUi8D4Y/arcgis/rest/services/Middle_Earth_Overlay_Map/MapServer/tile/{z}/{y}/{x}';
 
 let isActive = false;
-let savedStyle: string | object | null = null;
 let savedCenter: [number, number] | null = null;
 let savedZoom: number | null = null;
-let savedProjection: string | null = null;
+let savedLayerVisibility: Map<string, string> = new Map();
 let banner: HTMLElement | null = null;
 
-/** Create and show the "You have found the One Map" banner */
 function showBanner(): void {
   if (banner) return;
   banner = document.createElement('div');
@@ -68,7 +37,7 @@ function showBanner(): void {
   }, 4000);
 }
 
-/** Remove the banner if still visible */
+// Remove the banner if still visible
 function hideBanner(): void {
   banner?.remove();
   banner = null;
@@ -78,81 +47,73 @@ export function isMiddleEarthActive(): boolean {
   return isActive;
 }
 
-/**
- * Activate Middle-earth mode.
- * Saves the current map state, then swaps in the ME style + flies to Middle-earth.
- */
 export async function activateMiddleEarth(map: MaplibreGL.Map): Promise<void> {
   if (isActive) return;
   isActive = true;
 
-  // Save current state
   const center = map.getCenter();
   savedCenter = [center.lng, center.lat];
-  savedZoom = map.getZoom();
-  savedProjection = 'globe'; // default projection used by this app
-  savedStyle = map.getStyle();
+  savedZoom   = map.getZoom();
 
   showBanner();
 
-  // Swap style – try the community GeoJSON-based style first, fall back to ESRI raster
-  try {
-    await new Promise<void>((resolve, reject) => {
-      // Listen for style.load ONCE
-      const onLoaded = () => { map.off('style.load', onLoaded); resolve(); };
-      const onError = (e: any) => { map.off('error', onError); reject(e); };
-      map.once('style.load', onLoaded);
-      map.once('error', onError);
-      map.setStyle(MIDDLE_EARTH_STYLE);
-    });
-  } catch {
-    console.warn('[ME] Community style failed, falling back to ESRI raster tiles.');
-    await new Promise<void>((resolve) => {
-      map.once('style.load', () => resolve());
-      map.setStyle(buildMiddleEarthRasterStyle() as any);
-    });
+  // Hide all existing layers, saving their visibility
+  savedLayerVisibility.clear();
+  for (const layer of map.getStyle().layers) {
+    const vis = (map.getLayoutProperty(layer.id, 'visibility') as string) ?? 'visible';
+    savedLayerVisibility.set(layer.id, vis);
+    map.setLayoutProperty(layer.id, 'visibility', 'none');
   }
 
-  // Turn off globe projection – Middle-earth is flat (like Tolkien intended)
-  try {
-    map.setProjection({ type: 'mercator' } as any);
-  } catch { /* projection API may not be available */ }
+  if (!map.getLayer(ME_BG)) {
+    map.addLayer({ id: ME_BG, type: 'background', paint: { 'background-color': '#1a1008' } } as any);
+  }
 
-  // Fly to the centre of Middle-earth (Rohan/Gondor region in the image)
-  map.flyTo({
-    center: [0, 0],    // The tile service is centred on 0,0 by design
-    zoom: 3,
-    duration: 2500,
-    easing: (t) => t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t,
-  });
+  if (!map.getSource(ME_SOURCE)) {
+    map.addSource(ME_SOURCE, {
+      type: 'raster',
+      tiles: [ME_TILE_URL],
+      tileSize: 256,
+      attribution: '© Esri, Middle-earth',
+    });
+  }
+  if (!map.getLayer(ME_LAYER)) {
+    map.addLayer({ id: ME_LAYER, type: 'raster', source: ME_SOURCE } as any);
+  }
 
-  // Listen for Escape key to deactivate
+  map.setProjection({ type: 'mercator' } as any);
+
+  map.setMinZoom(2);
+  map.setMaxZoom(8);
+
+  map.flyTo({ center: [45, 52], zoom: 2.25});
   window.addEventListener('keydown', onEscape);
 }
 
-/**
- * Deactivate Middle-earth mode and restore the previous map state.
- */
 export async function deactivateMiddleEarth(map: MaplibreGL.Map): Promise<void> {
   if (!isActive) return;
   isActive = false;
   hideBanner();
   window.removeEventListener('keydown', onEscape);
 
-  if (!savedStyle) return;
+  if (map.getLayer(ME_LAYER)) map.removeLayer(ME_LAYER);
+  if (map.getLayer(ME_BG))    map.removeLayer(ME_BG);
+  if (map.getSource(ME_SOURCE)) map.removeSource(ME_SOURCE);
 
-  await new Promise<void>((resolve) => {
-    map.once('style.load', () => resolve());
-    map.setStyle(savedStyle as any);
-  });
+  // Restore globe projection and remove ME constraints
+  map.setProjection({ type: 'globe' } as any);
+  map.setMinZoom(0);
+  map.setMaxZoom(22);
 
-  if (savedProjection) {
-    try { map.setProjection({ type: savedProjection } as any); } catch { /* ignore */ }
+  // Restore all layer visibility
+  for (const [id, vis] of savedLayerVisibility) {
+    if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', vis);
   }
+  savedLayerVisibility.clear();
 
   map.flyTo({
     center: savedCenter ?? [10, 60],
-    zoom: savedZoom ?? 6,
+    zoom:   savedZoom   ?? 6,
     duration: 2000,
   });
 }
@@ -167,16 +128,11 @@ function onEscape(e: KeyboardEvent): void {
 
 /** The Konami Code sequence */
 const KONAMI = [
-  'ArrowUp', 'ArrowUp',
-  'ArrowDown', 'ArrowDown'
+  'g', 'a', 'n', 'd', 'a', 'l', 'f',
 ];
 
 let konamiIndex = 0;
 
-/**
- * Register the Konami Code listener on the document.
- * Pass the map instance so it can be toggled when the code is entered.
- */
 export function registerKonamiCode(map: MaplibreGL.Map): void {
   _mapRef = map;
   document.addEventListener('keydown', (e: KeyboardEvent) => {
@@ -192,7 +148,6 @@ export function registerKonamiCode(map: MaplibreGL.Map): void {
         }
       }
     } else {
-      // Partial reset – if first key matches, keep it
       konamiIndex = e.key === KONAMI[0] ? 1 : 0;
     }
   });

--- a/App/static/style/style.css
+++ b/App/static/style/style.css
@@ -1,4 +1,4 @@
-﻿.map-overlay {
+﻿﻿.map-overlay {
     position: absolute;
     top: 0;
     right: auto;
@@ -148,3 +148,77 @@
     color: rgba(194, 200, 202, 0.5);
     font-style: italic;
 }
+
+/* ── Middle-earth Easter Egg Banner ───────────────────────────────────────── */
+#me-banner {
+    position: fixed;
+    bottom: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 9999;
+    pointer-events: none;
+    animation: me-rise 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+#me-banner.me-fade-out {
+    animation: me-sink 0.6s ease-in forwards;
+}
+
+.me-inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.3rem;
+    background: rgba(10, 7, 4, 0.88);
+    border: 1px solid rgba(212, 175, 55, 0.55);
+    border-radius: 8px;
+    padding: 1rem 2rem 0.85rem;
+    box-shadow: 0 0 32px rgba(212, 175, 55, 0.3), 0 8px 24px rgba(0,0,0,0.6);
+    backdrop-filter: blur(6px);
+    white-space: nowrap;
+}
+
+.me-rune {
+    font-size: 2rem;
+    animation: me-spin 3s linear infinite;
+}
+
+.me-title {
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: 1.1rem;
+    font-weight: bold;
+    letter-spacing: 0.18em;
+    color: #d4af37;
+    text-shadow: 0 0 12px rgba(212, 175, 55, 0.8);
+}
+
+.me-subtitle {
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: 0.78rem;
+    color: rgba(212, 175, 55, 0.6);
+    letter-spacing: 0.06em;
+}
+
+.me-subtitle kbd {
+    background: rgba(212, 175, 55, 0.15);
+    border: 1px solid rgba(212, 175, 55, 0.35);
+    border-radius: 3px;
+    padding: 0 4px;
+    font-size: 0.75rem;
+}
+
+@keyframes me-rise {
+    from { opacity: 0; transform: translateX(-50%) translateY(1.5rem); }
+    to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+
+@keyframes me-sink {
+    from { opacity: 1; transform: translateX(-50%) translateY(0); }
+    to   { opacity: 0; transform: translateX(-50%) translateY(1.5rem); }
+}
+
+@keyframes me-spin {
+    from { transform: rotate(0deg); }
+    to   { transform: rotate(360deg); }
+}
+

--- a/App/static/style/style.css
+++ b/App/static/style/style.css
@@ -1,20 +1,32 @@
-﻿﻿.map-overlay {
-    position: absolute;
+﻿﻿html, body {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+}
+
+#map {
+    position: fixed !important;
     top: 0;
-    right: auto;
-    background: rgba(15,25,30,0.65);
+    left: 0;
+    width: 100vw !important;
+    height: 100vh !important;
+    z-index: 0;
+}
+
+.map-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: rgba(15,25,30,0.82);
     color: #fff;
     padding: 4px;
     border-bottom-right-radius: 6px;
     font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial;
     font-size: 12px;
-    z-index: 100;
+    z-index: 9999;
     pointer-events: auto;
-    width: 75vmax;
-    max-width: 75vw;
     box-shadow: 0 4px 12px rgba(15,25,30,0.35);
-    backdrop-filter: blur(0.1rem);
-    will-change: backdrop-filter;
     outline: 2px solid rgba(15,25,30,0.65);
 }
 
@@ -91,11 +103,11 @@
 
 .dropdown-menu {
     display: flex;
+    flex-direction: column;
     position: fixed;
     box-sizing: border-box;
     min-width: 180px;
-    z-index: 100;
-    flex-direction: column;
+    z-index: 9999;
     background: rgba(15,25,30,0.65);
     outline: 2px solid rgba(15,25,30,0.65);
     box-shadow: 0 4px 12px rgba(15,25,30,0.35);

--- a/App/static/style/style.css
+++ b/App/static/style/style.css
@@ -192,7 +192,6 @@
 
 .me-rune {
     font-size: 2rem;
-    animation: me-spin 3s linear infinite;
 }
 
 .me-title {
@@ -229,8 +228,4 @@
     to   { opacity: 0; transform: translateX(-50%) translateY(1.5rem); }
 }
 
-@keyframes me-spin {
-    from { transform: rotate(0deg); }
-    to   { transform: rotate(360deg); }
-}
 

--- a/App/templates/index.html
+++ b/App/templates/index.html
@@ -10,7 +10,7 @@
 </head>
 
 <body style="margin: 0;">
-  <div id="map" style="height: 100dvh; width: 100dvw;"></div>
+  <div id="map" style="width: 100vw; height: 100vh;"></div>
   <div class="map-overlay container">
     <div class="header box prevent-select">Map Application</div>
     <div class="dropdown">
@@ -18,7 +18,6 @@
     </div>
     <div class="box text prevent-select button">Controls</div>
   </div>
-  <!-- Dropdown menu lives outside .map-overlay so backdrop-filter works against the map -->
   <div class="dropdown-menu" id="layers-menu"></div>
   <script type="module" src="{{ url_for('static', filename='js/main.js') }}?v={{ ts }}"
         onerror="let s=document.createElement('script');s.type='module';s.src='../static/js/main.js';document.body.appendChild(s);">


### PR DESCRIPTION
This pull request introduces a fun Middle-earth "Easter egg" mode to the map application, activated by entering the Konami code "gandalf" on the keyboard. It includes new functionality for toggling a Middle-earth overlay map, updates to the main script to support this feature, and significant style changes to accommodate the new mode and improve overlay and dropdown appearance.

**Middle-earth mode feature:**

* Added `App/frontend/src/middleEarth.ts` with functions to activate/deactivate Middle-earth mode, including overlaying a themed map, showing a banner, and toggling via the Konami code "gandalf".
* Registered the Konami code handler in `App/frontend/src/main.ts`, enabling users to toggle the Middle-earth mode on the map by typing "gandalf". [[1]](diffhunk://#diff-bf7bca09c41c73178054a207355fdd8019eec29e3470c28e2f4126051799cf0aR9) [[2]](diffhunk://#diff-bf7bca09c41c73178054a207355fdd8019eec29e3470c28e2f4126051799cf0aR34)

**Styling improvements:**

* Updated `App/static/style/style.css` to add styles for the Middle-earth banner, increase overlay and dropdown z-index, and improve layout for full-screen map and overlays. [[1]](diffhunk://#diff-bb1700ec16bc5cd5daf414cbb38a03c8ab0e8c9a4a78b4bd34335de68870da9eL1-L17) [[2]](diffhunk://#diff-bb1700ec16bc5cd5daf414cbb38a03c8ab0e8c9a4a78b4bd34335de68870da9eR106-R110) [[3]](diffhunk://#diff-bb1700ec16bc5cd5daf414cbb38a03c8ab0e8c9a4a78b4bd34335de68870da9eR163-R231)

**HTML adjustments:**

* Modified `App/templates/index.html` to use standard viewport units for the map container, ensuring compatibility with the new styles.