### PR TITLE
Refactor/maints

### DIFF
--- a/App/frontend/src/layer.ts
+++ b/App/frontend/src/layer.ts
@@ -1,0 +1,69 @@
+import type * as MaplibreGL from "maplibre-gl";
+
+declare global {
+  interface Window {
+    // The global injected by the CDN; optional because it may not be present in some environments
+    maplibregl?: typeof MaplibreGL;
+    // Exposed for debugging
+    map?: MaplibreGL.Map;
+  }
+}
+
+const layersToggle = document.getElementById('layers-toggle');
+const layersMenu   = document.getElementById('layers-menu');
+
+// Open / close the dropdown when clicking the toggle button
+const overlay = document.querySelector('.map-overlay') as HTMLElement | null;
+layersToggle?.addEventListener('click', (e) => {
+  e.stopPropagation();
+  layersMenu?.classList.toggle('open');
+  overlay?.classList.toggle('dropdown-open');
+  // Align dropdown to span the full overlay width
+  if (layersMenu?.classList.contains('open') && overlay) {
+    const overlayRect = overlay.getBoundingClientRect();
+    layersMenu.style.top = overlayRect.bottom + 'px';
+    layersMenu.style.left = overlayRect.left + 'px';
+    layersMenu.style.width = overlayRect.width + 'px';
+  }
+});
+document.addEventListener('click', () => {
+  layersMenu?.classList.remove('open');
+  overlay?.classList.remove('dropdown-open');
+});
+// Prevent clicks inside the menu from closing it
+layersMenu?.addEventListener('click', (e) => e.stopPropagation());
+
+/**
+ * Register a map layer in the Layers dropdown so the user can toggle it.
+ *
+ * @param layerId The MapLibre layer id to toggle visibility for.
+ * @param label Human-readable label shown in the menu.
+ * @param visible Whether the layer starts visible (default true).
+ * @param map The map to add the layer to
+ */
+export function registerLayer(layerId: string, label: string, visible: boolean = true, map: MaplibreGL.Map) {
+  if (!layersMenu) return;
+
+  // Remove the "no layers" placeholder if present
+  const empty = layersMenu.querySelector('.dropdown-empty');
+  if (empty) empty.remove();
+
+  const item = document.createElement('label');
+  item.className = 'dropdown-item prevent-select';
+
+  const cb = document.createElement('input');
+  cb.type = 'checkbox';
+  cb.checked = visible;
+
+  cb.addEventListener('change', () => {
+    map.setLayoutProperty(layerId, 'visibility', cb.checked ? 'visible' : 'none');
+  });
+
+  const span = document.createElement('span');
+  span.textContent = label;
+
+  item.appendChild(cb);
+  item.appendChild(span);
+  layersMenu.appendChild(item);
+}
+

--- a/App/frontend/src/layer.ts
+++ b/App/frontend/src/layer.ts
@@ -42,7 +42,7 @@ layersMenu?.addEventListener('click', (e) => e.stopPropagation());
  * @param map The map to add the layer to
  */
 
-function registerLayer(layerId: string, label: string, visible: boolean = true, map: MaplibreGL.Map) {
+function registerLayer(layerId: string, label: string, visible: boolean, map: MaplibreGL.Map) {
   if (!layersMenu) return;
 
   // Remove the "no layers" placeholder if present
@@ -69,11 +69,24 @@ function registerLayer(layerId: string, label: string, visible: boolean = true, 
 }
 
 /**
- * Gets firestations from db api, and adds layer for each conty
+ * Gets firestations from db api, and adds layer for each county
  * @param map The map the layers are added to
  * @param fylkeIds The ids of the counties to request
+ * @param visible Controls if the layer is displayed once it's been loaded
  */
-export async function AddFireStationLayerGeospatial(map: MaplibreGL.Map, fylkeIds: number[]):Promise<void> {
+export async function AddFireStationLayerGeospatial(map: MaplibreGL.Map, fylkeIds: number[], visible: boolean=false):Promise<void> {
+  enum visibility{
+    'none' = 0,
+    'visible' = 1
+  }
+
+  let LayerVisibility : any  = visibility[visibility.none];
+
+  if (visible)
+  {
+    LayerVisibility = visibility[visibility.visible]
+  }
+
   for (const fylkeId of fylkeIds) {
     try {
       const res = await fetch(`/api/fylke/${fylkeId}`);
@@ -94,10 +107,12 @@ export async function AddFireStationLayerGeospatial(map: MaplibreGL.Map, fylkeId
           'circle-color': '#e74c3c',
           'circle-stroke-width': 1,
           'circle-stroke-color': '#ffffff',
-        },
+        },layout: {
+          visibility: LayerVisibility
+        }
       });
 
-      registerLayer(layerId, `Brannstasjoner Fylke ${fylkeNavn}`, true, map);
+      registerLayer(layerId, `Brannstasjoner Fylke ${fylkeNavn}`, visible, map);
 
       // Add event listeners (same as before)
       map.on('click', layerId, (e) => {

--- a/App/frontend/src/layer.ts
+++ b/App/frontend/src/layer.ts
@@ -1,5 +1,4 @@
 import type * as MaplibreGL from "maplibre-gl";
-
 declare global {
   interface Window {
     // The global injected by the CDN; optional because it may not be present in some environments
@@ -9,6 +8,7 @@ declare global {
   }
 }
 
+const maplibregl = window.maplibregl;
 const layersToggle = document.getElementById('layers-toggle');
 const layersMenu   = document.getElementById('layers-menu');
 
@@ -41,7 +41,8 @@ layersMenu?.addEventListener('click', (e) => e.stopPropagation());
  * @param visible Whether the layer starts visible (default true).
  * @param map The map to add the layer to
  */
-export function registerLayer(layerId: string, label: string, visible: boolean = true, map: MaplibreGL.Map) {
+
+function registerLayer(layerId: string, label: string, visible: boolean = true, map: MaplibreGL.Map) {
   if (!layersMenu) return;
 
   // Remove the "no layers" placeholder if present
@@ -67,3 +68,70 @@ export function registerLayer(layerId: string, label: string, visible: boolean =
   layersMenu.appendChild(item);
 }
 
+/**
+ * Gets firestations from db api, and adds layer for each conty
+ * @param map The map the layers are added to
+ * @param fylkeIds The ids of the counties to request
+ */
+export async function AddFireStationLayerGeospatial(map: MaplibreGL.Map, fylkeIds: number[]):Promise<void> {
+  for (const fylkeId of fylkeIds) {
+    try {
+      const res = await fetch(`/api/fylke/${fylkeId}`);
+      const geojson = await res.json();
+
+      const sourceId = `brannstasjoner-fylke-${fylkeId}`;
+      const layerId = `brannstasjoner-circle-${fylkeId}`;
+      const fylkeNavn = geojson.fylke_navn || `Fylke ${fylkeId}`;
+
+      map.addSource(sourceId, { type: 'geojson', data: geojson });
+
+      map.addLayer({
+        id: layerId,
+        type: 'circle',
+        source: sourceId,
+        paint: {
+          'circle-radius': 6,
+          'circle-color': '#e74c3c',
+          'circle-stroke-width': 1,
+          'circle-stroke-color': '#ffffff',
+        },
+      });
+
+      registerLayer(layerId, `Brannstasjoner Fylke ${fylkeNavn}`, true, map);
+
+      // Add event listeners (same as before)
+      map.on('click', layerId, (e) => {
+        if (!e.features || e.features.length === 0) return;
+        const feature = e.features[0];
+        const coords = (feature.geometry as GeoJSON.Point).coordinates.slice() as [number, number];
+        const props = feature.properties || {} as Record<string, string>;
+
+        const html = `
+          <div style="font-family: sans-serif; max-width: 260px;">
+            <h3 style="margin: 0 0 6px 0; font-size: 14px;">${props.brannstasjon || 'Ukjent stasjon'}</h3>
+            ${props.brannvesen ? `<p style="margin: 2px 0;"><strong>Brannvesen:</strong> ${props.brannvesen}</p>` : ''}
+            ${props.stasjonstype ? `<p style="margin: 2px 0;"><strong>Stasjonstype:</strong> ${props.stasjonstype}</p>` : ''}
+            ${props.kasernert ? `<p style="margin: 2px 0;"><strong>Kasernert:</strong> ${props.kasernert}</p>` : ''}
+            <p style="margin: 2px 0;"><strong>Koordinater:</strong> ${coords[1].toFixed(6)}, ${coords[0].toFixed(6)}</p>
+          </div>`;
+
+        while (Math.abs(e.lngLat.lng - coords[0]) > 180) {
+          coords[0] += e.lngLat.lng > coords[0] ? 360 : -360;
+        }
+
+        if (maplibregl) {
+          new maplibregl.Popup({ offset: 10 }).setLngLat(coords).setHTML(html).addTo(map);
+        }
+      });
+
+      map.on('mouseenter', layerId, () => { map.getCanvas().style.cursor = 'pointer'; });
+      map.on('mouseleave', layerId, () => { map.getCanvas().style.cursor = ''; });
+
+      // Optional: add a small delay between requests
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+    } catch (err) {
+      console.error(`Failed to load brannstasjoner for fylke ${fylkeId}:`, err);
+    }
+  }
+}

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -25,8 +25,8 @@ if (!maplibregl) {
   const map = new maplibregl.Map({
     container: 'map' as string,
     style: '../static/style/mapstyle.json' as string,
-    center: [0, 0] as LngLatLike,
-    zoom: 6 as number,
+    center: [8.0, 59.0] as LngLatLike,
+    zoom: 2 as number,
   });
 
   window.map = map;

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -1,5 +1,4 @@
-﻿// Use the global provided by the CDN instead of importing a node-style package
-import type * as MaplibreGL from 'maplibre-gl';
+﻿import type * as MaplibreGL from 'maplibre-gl';
 import {
   AddLayerObject,
   LayerSpecification,
@@ -7,8 +6,7 @@ import {
   PropertyValueSpecification
 } from "maplibre-gl";
 import { registerKonamiCode } from './middleEarth.js';
-import {registerLayer} from './layer.js'
-
+import {AddFireStationLayerGeospatial} from './layer.js'
 
 declare global {
   interface Window {
@@ -33,10 +31,6 @@ if (!maplibregl) {
 
   window.map = map;
   registerKonamiCode(map);
-
-
-
-
 
   const geolocate = new maplibregl.GeolocateControl({
     positionOptions: { enableHighAccuracy: true as boolean },
@@ -212,70 +206,7 @@ if (!maplibregl) {
         ]);
       }
     }
-
-    async function loadFylkerSequentially() {
-  const fylkeIds = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
-
-  for (const fylkeId of fylkeIds) {
-    try {
-      const res = await fetch(`/api/fylke/${fylkeId}`);
-      const geojson = await res.json();
-
-      const sourceId = `brannstasjoner-fylke-${fylkeId}`;
-      const layerId = `brannstasjoner-circle-${fylkeId}`;
-      const fylkeNavn = geojson.fylke_navn || `Fylke ${fylkeId}`;
-
-      map.addSource(sourceId, { type: 'geojson', data: geojson });
-
-      map.addLayer({
-        id: layerId,
-        type: 'circle',
-        source: sourceId,
-        paint: {
-          'circle-radius': 6,
-          'circle-color': '#e74c3c',
-          'circle-stroke-width': 1,
-          'circle-stroke-color': '#ffffff',
-        },
-      });
-
-      registerLayer(layerId, `Brannstasjoner Fylke ${fylkeNavn}`, true, map);
-
-      // Add event listeners (same as before)
-      map.on('click', layerId, (e) => {
-        if (!e.features || e.features.length === 0) return;
-        const feature = e.features[0];
-        const coords = (feature.geometry as GeoJSON.Point).coordinates.slice() as [number, number];
-        const props = feature.properties || {} as Record<string, string>;
-
-        const html = `
-          <div style="font-family: sans-serif; max-width: 260px;">
-            <h3 style="margin: 0 0 6px 0; font-size: 14px;">${props.brannstasjon || 'Ukjent stasjon'}</h3>
-            ${props.brannvesen ? `<p style="margin: 2px 0;"><strong>Brannvesen:</strong> ${props.brannvesen}</p>` : ''}
-            ${props.stasjonstype ? `<p style="margin: 2px 0;"><strong>Stasjonstype:</strong> ${props.stasjonstype}</p>` : ''}
-            ${props.kasernert ? `<p style="margin: 2px 0;"><strong>Kasernert:</strong> ${props.kasernert}</p>` : ''}
-            <p style="margin: 2px 0;"><strong>Koordinater:</strong> ${coords[1].toFixed(6)}, ${coords[0].toFixed(6)}</p>
-          </div>`;
-
-        while (Math.abs(e.lngLat.lng - coords[0]) > 180) {
-          coords[0] += e.lngLat.lng > coords[0] ? 360 : -360;
-        }
-
-        new maplibregl.Popup({ offset: 10 }).setLngLat(coords).setHTML(html).addTo(map);
-      });
-
-      map.on('mouseenter', layerId, () => { map.getCanvas().style.cursor = 'pointer'; });
-      map.on('mouseleave', layerId, () => { map.getCanvas().style.cursor = ''; });
-
-      // Optional: add a small delay between requests
-      await new Promise(resolve => setTimeout(resolve, 100));
-
-    } catch (err) {
-      console.error(`Failed to load brannstasjoner for fylke ${fylkeId}:`, err);
-    }
+    const fylkeIds = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    AddFireStationLayerGeospatial(map, fylkeIds);
   }
-}
-
-loadFylkerSequentially();
-
-})}
+)}

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -7,6 +7,7 @@ import {
   PropertyValueSpecification
 } from "maplibre-gl";
 import { registerKonamiCode } from './middleEarth.js';
+import {registerLayer} from './layer.js'
 
 
 declare global {
@@ -33,62 +34,9 @@ if (!maplibregl) {
   window.map = map;
   registerKonamiCode(map);
 
-  const layersToggle = document.getElementById('layers-toggle');
-  const layersMenu   = document.getElementById('layers-menu');
 
-  // Open / close the dropdown when clicking the toggle button
-  const overlay = document.querySelector('.map-overlay') as HTMLElement | null;
-  layersToggle?.addEventListener('click', (e) => {
-    e.stopPropagation();
-    layersMenu?.classList.toggle('open');
-    overlay?.classList.toggle('dropdown-open');
-    // Align dropdown to span the full overlay width
-    if (layersMenu?.classList.contains('open') && overlay) {
-      const overlayRect = overlay.getBoundingClientRect();
-      layersMenu.style.top = overlayRect.bottom + 'px';
-      layersMenu.style.left = overlayRect.left + 'px';
-      layersMenu.style.width = overlayRect.width + 'px';
-    }
-  });
-  document.addEventListener('click', () => {
-    layersMenu?.classList.remove('open');
-    overlay?.classList.remove('dropdown-open');
-  });
-  // Prevent clicks inside the menu from closing it
-  layersMenu?.addEventListener('click', (e) => e.stopPropagation());
 
-  /**
-   * Register a map layer in the Layers dropdown so the user can toggle it.
-   *
-   * @param layerId   – The MapLibre layer id to toggle visibility for.
-   * @param label     – Human-readable label shown in the menu.
-   * @param visible   – Whether the layer starts visible (default true).
-   */
-  function registerLayer(layerId: string, label: string, visible: boolean = true) {
-    if (!layersMenu) return;
 
-    // Remove the "no layers" placeholder if present
-    const empty = layersMenu.querySelector('.dropdown-empty');
-    if (empty) empty.remove();
-
-    const item = document.createElement('label');
-    item.className = 'dropdown-item prevent-select';
-
-    const cb = document.createElement('input');
-    cb.type = 'checkbox';
-    cb.checked = visible;
-
-    cb.addEventListener('change', () => {
-      map.setLayoutProperty(layerId, 'visibility', cb.checked ? 'visible' : 'none');
-    });
-
-    const span = document.createElement('span');
-    span.textContent = label;
-
-    item.appendChild(cb);
-    item.appendChild(span);
-    layersMenu.appendChild(item);
-  }
 
   const geolocate = new maplibregl.GeolocateControl({
     positionOptions: { enableHighAccuracy: true as boolean },
@@ -291,7 +239,7 @@ if (!maplibregl) {
         },
       });
 
-      registerLayer(layerId, `Brannstasjoner Fylke ${fylkeNavn}`, true);
+      registerLayer(layerId, `Brannstasjoner Fylke ${fylkeNavn}`, true, map);
 
       // Add event listeners (same as before)
       map.on('click', layerId, (e) => {


### PR DESCRIPTION
This pull request refactors the frontend map layer management code by extracting the fire station layer logic and layer toggle UI into a new module, improving code organization and maintainability. It also updates the map’s initial view and simplifies the main entry point. The most important changes are:

**Refactoring and Modularization:**

* Extracted all fire station layer logic, including fetching, adding to the map, event handling, and registration in the layers dropdown, into a new `AddFireStationLayerGeospatial` function in `layer.ts`. This removes duplicated code and keeps `main.ts` cleaner.
* Moved the layer toggle dropdown UI logic and the `registerLayer` function into `layer.ts`, further modularizing the codebase. [[1]](diffhunk://#diff-561499f5e3ef62d10389db34fcbf8277f353409c63f100f6f0e936522a52ac4cR1-R152) [[2]](diffhunk://#diff-bf7bca09c41c73178054a207355fdd8019eec29e3470c28e2f4126051799cf0aL29-L92)

**Code Simplification and Usage:**

* Updated `main.ts` to import and use the new `AddFireStationLayerGeospatial` function, replacing the previous inline logic for loading fire station layers. [[1]](diffhunk://#diff-bf7bca09c41c73178054a207355fdd8019eec29e3470c28e2f4126051799cf0aL1-R9) [[2]](diffhunk://#diff-bf7bca09c41c73178054a207355fdd8019eec29e3470c28e2f4126051799cf0aL267-R212)

**Map Initialization Improvements:**

* Changed the map’s initial center and zoom to `[8.0, 59.0]` and `2` respectively, providing a more suitable default view.

These changes improve code clarity, reusability, and make it easier to add or modify map layers in the future.