### PR TITLE
Visual/maplayers

### DIFF
--- a/App/frontend/src/interfaces.ts
+++ b/App/frontend/src/interfaces.ts
@@ -1,0 +1,79 @@
+﻿import type * as MaplibreGL from "maplibre-gl";
+
+declare global {
+  interface Window {
+    // The global injected by the CDN; optional because it may not be present in some environments
+    maplibregl?: typeof MaplibreGL;
+    // Exposed for debugging
+    map?: MaplibreGL.Map;
+    // Debug override for geolocation (for testing with DevTools sensor)
+    debugGeoLocation?: { lat: number; lng: number };
+  }
+}
+
+/**
+ * Shelter feature type
+ */
+export type ShelterFeature = GeoJSON.Feature<GeoJSON.Point, ShelterFeatureProperties>;
+
+/**
+ * Shelter fylke ID type
+ */
+export type ShelterFylkeId = ShelterFeatureProperties['fylkeId'];
+
+export interface WmsRasterLayerConfig {
+  sourceId: string;
+  layerId: string;
+  label: string;
+  tileUrl: string;
+  opacity?: number;
+}
+
+export interface ShelterFeatureProperties {
+  fylkeId: number;
+  [key: string]: unknown;
+}
+
+export interface GraphNode {
+  id: string;
+  neighbors: Array<{ nodeId: string; segment: any }>;
+  lat: number;
+  lng: number;
+}
+
+export interface RoadSegment {
+  coordinates: [number, number][];
+  distance: number;
+  start: any;
+  end: any;
+}
+
+export interface MapBounds {
+  minLng: number;
+  maxLng: number;
+  minLat: number;
+  maxLat: number;
+}
+
+export interface CacheBounds {
+  minLat: number;
+  maxLat: number;
+  minLng: number;
+  maxLng: number;
+}
+
+export interface StarsLayerOptions {
+  id?: string;
+  intensity?: number;
+  density?: number;
+}
+
+export interface RegisterStyleOptions {
+  id: string;
+  tiles: string[];
+  type: 'raster' | 'vector';
+  tileSize?: number;
+  attribution?: string;
+  fadeZoomStart?: number;
+  fadeZoomEnd?: number;
+}

--- a/App/frontend/src/layer.ts
+++ b/App/frontend/src/layer.ts
@@ -11,9 +11,14 @@ declare global {
 const maplibregl = window.maplibregl;
 const layersToggle = document.getElementById('layers-toggle');
 const layersMenu   = document.getElementById('layers-menu');
+const stylesToggle = document.getElementById('styles-toggle');
+const stylesMenu   = document.getElementById('styles-menu');
 
 // Map to store checkbox references by layer ID for programmatic updates
 const layerCheckboxes = new Map<string, HTMLInputElement>();
+
+// Set to track which layers are style layers (created by registerStyle)
+const styleLayers = new Set<string>();
 
 function createShelterPopup(map: MaplibreGL.Map, feature: GeoJSON.Feature, lngLat?: { lng: number; lat: number }): void {
   const coords = (feature.geometry as GeoJSON.Point).coordinates.slice() as [number, number];
@@ -95,6 +100,22 @@ document.addEventListener('click', () => {
 // Prevent clicks inside the menu from closing it
 layersMenu?.addEventListener('click', (e) => e.stopPropagation());
 
+// Open / close the styles dropdown when clicking the toggle button
+stylesToggle?.addEventListener('click', (e) => {
+  e.stopPropagation();
+  stylesMenu?.classList.toggle('open');
+  overlay?.classList.toggle('dropdown-open');
+  // Align dropdown to span the full overlay width
+  if (stylesMenu?.classList.contains('open') && overlay) {
+    const overlayRect = overlay.getBoundingClientRect();
+    stylesMenu.style.top = overlayRect.bottom + 'px';
+    stylesMenu.style.left = overlayRect.left + 'px';
+    stylesMenu.style.width = overlayRect.width + 'px';
+  }
+});
+// Prevent clicks inside the styles menu from closing it
+stylesMenu?.addEventListener('click', (e) => e.stopPropagation());
+
 /**
  * Register a map layer in the Layers dropdown so the user can toggle it.
  *
@@ -130,6 +151,62 @@ function registerLayer(layerId: string, label: string, visible: boolean, map: Ma
 
   // Store checkbox reference for programmatic updates
   layerCheckboxes.set(layerId, cb);
+}
+
+/**
+ * Register a style layer in the Layers dropdown so the user can toggle it.
+ * Only layers created by registerStyle() should use this function.
+ *
+ * @param styleId The style id (as used in registerStyle)
+ * @param label Human-readable label shown in the menu
+ * @param visible Whether the layer starts visible (default false)
+ * @param map The map instance
+ */
+export function registerStyleLayer(styleId: string, label: string, visible: boolean, map: MaplibreGL.Map): void {
+  const layerId = `${styleId}-layer`;
+
+  // Track this as a style layer
+  styleLayers.add(layerId);
+
+  // Register in the UI using the existing registerLayer function
+  registerLayer(layerId, label, visible, map);
+}
+
+/**
+ * Register a style layer in the Styles dropdown menu so the user can toggle it.
+ * @param styleId The style id (as used in registerStyle)
+ * @param label Human-readable label shown in the menu
+ * @param visible Whether the layer starts visible (default false)
+ * @param map The map instance
+ */
+export function registerStyleInMenu(styleId: string, label: string, visible: boolean, map: MaplibreGL.Map): void {
+  if (!stylesMenu) return;
+
+  // Remove the "no styles" placeholder if present
+  const empty = stylesMenu.querySelector('.dropdown-empty');
+  if (empty) empty.remove();
+
+  const layerId = `${styleId}-layer`;
+
+  const item = document.createElement('label');
+  item.className = 'dropdown-item prevent-select';
+
+  const cb = document.createElement('input');
+  cb.type = 'checkbox';
+  cb.checked = visible;
+
+  cb.addEventListener('change', () => {
+    if (map.getLayer(layerId)) {
+      map.setLayoutProperty(layerId, 'visibility', cb.checked ? 'visible' : 'none');
+    }
+  });
+
+  const span = document.createElement('span');
+  span.textContent = label;
+
+  item.appendChild(cb);
+  item.appendChild(span);
+  stylesMenu.appendChild(item);
 }
 
 /**
@@ -414,3 +491,21 @@ export function ClearShortestPathLayer(map: MaplibreGL.Map): void {
   const btn = document.getElementById('clear-path-btn');
   if (btn) btn.style.display = 'none';
 }
+
+/**
+ * Checks if a layer is a style layer (created by registerStyle)
+ * @param layerId The layer ID to check
+ * @returns true if the layer is a style layer
+ */
+export function isStyleLayer(layerId: string): boolean {
+  return styleLayers.has(layerId);
+}
+
+/**
+ * Gets all registered style layers
+ * @returns Array of style layer IDs
+ */
+export function getStyleLayers(): string[] {
+  return Array.from(styleLayers);
+}
+

--- a/App/frontend/src/layer.ts
+++ b/App/frontend/src/layer.ts
@@ -1,4 +1,9 @@
 import type * as MaplibreGL from "maplibre-gl";
+import {
+  layerCheckboxes,
+  registerLayer,
+} from './layerControl.js';
+
 declare global {
   interface Window {
     // The global injected by the CDN; optional because it may not be present in some environments
@@ -9,18 +14,11 @@ declare global {
 }
 
 const maplibregl = window.maplibregl;
-const layersToggle = document.getElementById('layers-toggle');
-const layersMenu   = document.getElementById('layers-menu');
-const stylesToggle = document.getElementById('styles-toggle');
-const stylesMenu   = document.getElementById('styles-menu');
 
 const WMS_PROXY = '/api/wms-proxy';
 const DSB_WMS_BASE_URL = 'https://ogc.dsb.no/wms.ashx';
 const GEONORGE_GRUNNKART_BASE_URL = 'https://wms.geonorge.no/skwms1/wms.norges_grunnkart';
 
-// Tracks visible layers and active dropdowns
-const layerCheckboxes = new Map<string, HTMLInputElement>();
-const styleLayers = new Set<string>();
 
 function createShelterPopup(map: MaplibreGL.Map, feature: GeoJSON.Feature, lngLat?: { lng: number; lat: number }): void {
   const coords = (feature.geometry as GeoJSON.Point).coordinates.slice() as [number, number];
@@ -46,7 +44,7 @@ function createShelterPopup(map: MaplibreGL.Map, feature: GeoJSON.Feature, lngLa
     new maplibregl.Popup({ offset: 10 }).setLngLat(coords).setHTML(html).addTo(map);
   }
 }
-
+// Layer configuration constants
 // Geonorge Vann og vassdrag layers
 // Layer names sourced from GetCapabilities: wms.norges_grunnkart
 const GEONORGE_VANN_LAYERS: { name: string; title: string }[] = [
@@ -70,153 +68,6 @@ const DSB_WMS_LAYERS: { name: string; title: string }[] = [
   { name: 'layer_444', title: 'Nødnett dekning håndholdt' },
   { name: 'layer_443', title: 'Nødnett dekning kjøretøymontert' },
 ];
-
-// Helper function to close both dropdowns
-function closeAllDropdowns() {
-  layersMenu?.classList.remove('open');
-  stylesMenu?.classList.remove('open');
-  overlay?.classList.remove('dropdown-open');
-}
-
-// Helper function to open a specific dropdown
-function openDropdown(menu: HTMLElement | null, toggle: HTMLElement | null) {
-  if (!menu || !overlay) return;
-
-  // Close the other menu
-  if (menu === layersMenu) {
-    stylesMenu?.classList.remove('open');
-  } else {
-    layersMenu?.classList.remove('open');
-  }
-
-  // Open the selected menu
-  menu.classList.add('open');
-  overlay.classList.add('dropdown-open');
-
-  // Align dropdown to span the full overlay width
-  const overlayRect = overlay.getBoundingClientRect();
-  menu.style.top = overlayRect.bottom + 'px';
-  menu.style.left = overlayRect.left + 'px';
-  menu.style.width = overlayRect.width + 'px';
-}
-
-// Open / close the dropdown when clicking the toggle button
-const overlay = document.querySelector('.map-overlay') as HTMLElement | null;
-layersToggle?.addEventListener('click', (e) => {
-  e.stopPropagation();
-  const isOpen = layersMenu?.classList.contains('open');
-  closeAllDropdowns();
-  if (!isOpen) {
-    openDropdown(layersMenu, layersToggle);
-  }
-});
-
-document.addEventListener('click', () => {
-  closeAllDropdowns();
-});
-
-// Prevent clicks inside the menu from closing it
-layersMenu?.addEventListener('click', (e) => e.stopPropagation());
-
-// Open / close the styles dropdown when clicking the toggle button
-stylesToggle?.addEventListener('click', (e) => {
-  e.stopPropagation();
-  const isOpen = stylesMenu?.classList.contains('open');
-  closeAllDropdowns();
-  if (!isOpen) {
-    openDropdown(stylesMenu, stylesToggle);
-  }
-});
-
-// Prevent clicks inside the styles menu from closing it
-stylesMenu?.addEventListener('click', (e) => e.stopPropagation());
-
-/**
- * Register a map layer in the Layers dropdown so the user can toggle it.
- * @param layerId The MapLibre layer id to toggle visibility for.
- * @param label Human-readable label shown in the menu.
- * @param visible Whether the layer starts visible (default true).
- * @param map The map to add the layer to
- */
-function registerLayer(layerId: string, label: string, visible: boolean, map: MaplibreGL.Map) {
-  if (!layersMenu) return;
-
-  // Remove the "no layers" placeholder if present
-  const empty = layersMenu.querySelector('.dropdown-empty');
-  if (empty) empty.remove();
-
-  const item = document.createElement('label');
-  item.className = 'dropdown-item prevent-select';
-
-  const cb = document.createElement('input');
-  cb.type = 'checkbox';
-  cb.checked = visible;
-
-  cb.addEventListener('change', () => {
-    map.setLayoutProperty(layerId, 'visibility', cb.checked ? 'visible' : 'none');
-  });
-
-  const span = document.createElement('span');
-  span.textContent = label;
-
-  item.appendChild(cb);
-  item.appendChild(span);
-  layersMenu.appendChild(item);
-
-  layerCheckboxes.set(layerId, cb);
-}
-
-/**
- * Register a style layer in the Layers dropdown so the user can toggle it.
- * Only layers created by registerStyle() should use this function.
- * @param styleId The style id (as used in registerStyle)
- * @param label Human-readable label shown in the menu
- * @param visible Whether the layer starts visible (default false)
- * @param map The map instance
- */
-export function registerStyleLayer(styleId: string, label: string, visible: boolean, map: MaplibreGL.Map): void {
-  const layerId = `${styleId}-layer`;
-
-  styleLayers.add(layerId);
-  registerLayer(layerId, label, visible, map);
-}
-
-/**
- * Register a style layer in the Styles dropdown menu so the user can toggle it.
- * @param styleId The style id (as used in registerStyle)
- * @param label Human-readable label shown in the menu
- * @param visible Whether the layer starts visible (default false)
- * @param map The map instance
- */
-export function registerStyleInMenu(styleId: string, label: string, visible: boolean, map: MaplibreGL.Map): void {
-  if (!stylesMenu) return;
-
-  // Remove the "no styles" placeholder if present
-  const empty = stylesMenu.querySelector('.dropdown-empty');
-  if (empty) empty.remove();
-
-  const layerId = `${styleId}-layer`;
-
-  const item = document.createElement('label');
-  item.className = 'dropdown-item prevent-select';
-
-  const cb = document.createElement('input');
-  cb.type = 'checkbox';
-  cb.checked = visible;
-
-  cb.addEventListener('change', () => {
-    if (map.getLayer(layerId)) {
-      map.setLayoutProperty(layerId, 'visibility', cb.checked ? 'visible' : 'none');
-    }
-  });
-
-  const span = document.createElement('span');
-  span.textContent = label;
-
-  item.appendChild(cb);
-  item.appendChild(span);
-  stylesMenu.appendChild(item);
-}
 
 interface WmsRasterLayerConfig {
   sourceId: string;
@@ -497,21 +348,4 @@ export function ClearShortestPathLayer(map: MaplibreGL.Map): void {
 
   const btn = document.getElementById('clear-path-btn');
   if (btn) btn.style.display = 'none';
-}
-
-/**
- * Checks if a layer is a style layer (created by registerStyle)
- * @param layerId The layer ID to check
- * @returns true if the layer is a style layer
- */
-export function isStyleLayer(layerId: string): boolean {
-  return styleLayers.has(layerId);
-}
-
-/**
- * Gets all registered style layers
- * @returns Array of style layer IDs
- */
-export function getStyleLayers(): string[] {
-  return Array.from(styleLayers);
 }

--- a/App/frontend/src/layer.ts
+++ b/App/frontend/src/layer.ts
@@ -14,10 +14,12 @@ const layersMenu   = document.getElementById('layers-menu');
 const stylesToggle = document.getElementById('styles-toggle');
 const stylesMenu   = document.getElementById('styles-menu');
 
-// Map to store checkbox references by layer ID for programmatic updates
-const layerCheckboxes = new Map<string, HTMLInputElement>();
+const WMS_PROXY = '/api/wms-proxy';
+const DSB_WMS_BASE_URL = 'https://ogc.dsb.no/wms.ashx';
+const GEONORGE_GRUNNKART_BASE_URL = 'https://wms.geonorge.no/skwms1/wms.norges_grunnkart';
 
-// Set to track which layers are style layers (created by registerStyle)
+// Tracks visible layers and active dropdowns
+const layerCheckboxes = new Map<string, HTMLInputElement>();
 const styleLayers = new Set<string>();
 
 function createShelterPopup(map: MaplibreGL.Map, feature: GeoJSON.Feature, lngLat?: { lng: number; lat: number }): void {
@@ -44,16 +46,6 @@ function createShelterPopup(map: MaplibreGL.Map, feature: GeoJSON.Feature, lngLa
     new maplibregl.Popup({ offset: 10 }).setLngLat(coords).setHTML(html).addTo(map);
   }
 }
-
-/**
- * Backend proxy base URL for WMS tiles.
- * Routing tiles through the backend allows future server-side raster analysis
- * (e.g. classification, overlay computations) without changing the frontend.
- * Pass the upstream WMS base URL via the `url` query parameter.
- */
-const WMS_PROXY = '/api/wms-proxy';
-const DSB_WMS_BASE_URL = 'https://ogc.dsb.no/wms.ashx';
-const GEONORGE_GRUNNKART_BASE_URL = 'https://wms.geonorge.no/skwms1/wms.norges_grunnkart';
 
 // Geonorge Vann og vassdrag layers
 // Layer names sourced from GetCapabilities: wms.norges_grunnkart
@@ -141,7 +133,6 @@ stylesMenu?.addEventListener('click', (e) => e.stopPropagation());
 
 /**
  * Register a map layer in the Layers dropdown so the user can toggle it.
- *
  * @param layerId The MapLibre layer id to toggle visibility for.
  * @param label Human-readable label shown in the menu.
  * @param visible Whether the layer starts visible (default true).
@@ -172,14 +163,12 @@ function registerLayer(layerId: string, label: string, visible: boolean, map: Ma
   item.appendChild(span);
   layersMenu.appendChild(item);
 
-  // Store checkbox reference for programmatic updates
   layerCheckboxes.set(layerId, cb);
 }
 
 /**
  * Register a style layer in the Layers dropdown so the user can toggle it.
  * Only layers created by registerStyle() should use this function.
- *
  * @param styleId The style id (as used in registerStyle)
  * @param label Human-readable label shown in the menu
  * @param visible Whether the layer starts visible (default false)
@@ -188,10 +177,7 @@ function registerLayer(layerId: string, label: string, visible: boolean, map: Ma
 export function registerStyleLayer(styleId: string, label: string, visible: boolean, map: MaplibreGL.Map): void {
   const layerId = `${styleId}-layer`;
 
-  // Track this as a style layer
   styleLayers.add(layerId);
-
-  // Register in the UI using the existing registerLayer function
   registerLayer(layerId, label, visible, map);
 }
 
@@ -232,121 +218,121 @@ export function registerStyleInMenu(styleId: string, label: string, visible: boo
   stylesMenu.appendChild(item);
 }
 
+interface WmsRasterLayerConfig {
+  sourceId: string;
+  layerId: string;
+  label: string;
+  tileUrl: string;
+  opacity?: number;
+}
+
 /**
- * Adds all DSB WMS layers to the map as individual raster layers,
- * each registered in the layers toggle dropdown.
- * @param map The MapLibre map instance to add layers to
- * @param visible Whether the layers start visible (default false)
+ * Generic function to add WMS layers from a configuration array
+ * @param map The MapLibre map instance
+ * @param layers Array of layer configurations with name and title
+ * @param configBuilder Function that builds the tile URL and layer config from a layer
+ * @param visible Whether the layers start visible
+ */
+function addWmsLayers<T extends { name: string; title: string }>(
+  map: MaplibreGL.Map,
+  layers: T[],
+  configBuilder: (layer: T) => WmsRasterLayerConfig,
+  visible: boolean = false
+): void {
+  const visibility = visible ? 'visible' : 'none';
+
+  for (const layer of layers) {
+    const config = configBuilder(layer);
+    const { sourceId, layerId, label, tileUrl, opacity = 0.85 } = config;
+
+    map.addSource(sourceId, {
+      type: 'raster',
+      tiles: [tileUrl],
+      tileSize: 256,
+    });
+
+    map.addLayer({
+      id: layerId,
+      type: 'raster',
+      source: sourceId,
+      paint: { 'raster-opacity': opacity },
+      layout: { visibility },
+    });
+
+    registerLayer(layerId, label, visible, map);
+  }
+}
+
+/**
+ * Wrapper function to add the DSB WMS layers to the map
  */
 export function AddDSBWmsLayers(map: MaplibreGL.Map, visible: boolean = false): void {
-  const visibility = visible ? 'visible' : 'none';
-
-  for (const layer of DSB_WMS_LAYERS) {
-    const sourceId = `dsb-wms-${layer.name}`;
-    const layerId  = `dsb-wms-layer-${layer.name}`;
-
-    const tileUrl =
-      `${WMS_PROXY}/5?url=${encodeURIComponent(DSB_WMS_BASE_URL)}&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap` +
-      `&LAYERS=${layer.name}&STYLES=en` +
-      `&FORMAT=image/png&TRANSPARENT=true` +
-      `&CRS=EPSG:3857` +
-      `&BBOX={bbox-epsg-3857}&WIDTH=256&HEIGHT=256`;
-
-    map.addSource(sourceId, {
-      type: 'raster',
-      tiles: [tileUrl],
-      tileSize: 256,
-    });
-
-    map.addLayer({
-      id: layerId,
-      type: 'raster',
-      source: sourceId,
-      paint: { 'raster-opacity': 0.85 },
-      layout: { visibility },
-    });
-
-    registerLayer(layerId, `DSB: ${layer.title}`, visible, map);
-  }
+  addWmsLayers(
+    map,
+    DSB_WMS_LAYERS,
+    (layer) => ({
+      sourceId: `dsb-wms-${layer.name}`,
+      layerId: `dsb-wms-layer-${layer.name}`,
+      label: `DSB: ${layer.title}`,
+      tileUrl:
+        `${WMS_PROXY}/5?url=${encodeURIComponent(DSB_WMS_BASE_URL)}&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap` +
+        `&LAYERS=${layer.name}&STYLES=en` +
+        `&FORMAT=image/png&TRANSPARENT=true` +
+        `&CRS=EPSG:3857` +
+        `&BBOX={bbox-epsg-3857}&WIDTH=256&HEIGHT=256`,
+      opacity: 0.85,
+    }),
+    visible
+  );
 }
 
 /**
- * Adds the Geonorge "Vann og vassdrag" WMS layers (Vannflater + Vassdrag)
- * to the map, routed through the backend proxy for caching and future
- * raster analysis.
- * @param map     The MapLibre map instance
- * @param visible Whether the layers start visible (default false)
+ * Wrapper function to add the Geonorge Vann og Vassdrag WMS layers to the map
  */
 export function AddVannOgVassdragLayers(map: MaplibreGL.Map, visible: boolean = false): void {
-  const visibility = visible ? 'visible' : 'none';
-
-  for (const layer of GEONORGE_VANN_LAYERS) {
-    const sourceId = `geonorge-vann-${layer.name.toLowerCase()}`;
-    const layerId  = `geonorge-vann-layer-${layer.name.toLowerCase()}`;
-
-    const tileUrl =
-      `${WMS_PROXY}/5?url=${encodeURIComponent(GEONORGE_GRUNNKART_BASE_URL)}&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap` +
-      `&LAYERS=${layer.name}&STYLES=` +
-      `&FORMAT=image/png&TRANSPARENT=true` +
-      `&CRS=EPSG:3857` +
-      `&BBOX={bbox-epsg-3857}&WIDTH=256&HEIGHT=256`;
-
-    map.addSource(sourceId, {
-      type: 'raster',
-      tiles: [tileUrl],
-      tileSize: 256,
-    });
-
-    map.addLayer({
-      id: layerId,
-      type: 'raster',
-      source: sourceId,
-      paint: { 'raster-opacity': 0.85 },
-      layout: { visibility },
-    });
-
-    registerLayer(layerId, `Vann og vassdrag: ${layer.title}`, visible, map);
-  }
+  addWmsLayers(
+    map,
+    GEONORGE_VANN_LAYERS,
+    (layer) => ({
+      sourceId: `geonorge-vann-${layer.name.toLowerCase()}`,
+      layerId: `geonorge-vann-layer-${layer.name.toLowerCase()}`,
+      label: `Vann og vassdrag: ${layer.title}`,
+      tileUrl:
+        `${WMS_PROXY}/5?url=${encodeURIComponent(GEONORGE_GRUNNKART_BASE_URL)}&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap` +
+        `&LAYERS=${layer.name}&STYLES=` +
+        `&FORMAT=image/png&TRANSPARENT=true` +
+        `&CRS=EPSG:3857` +
+        `&BBOX={bbox-epsg-3857}&WIDTH=256&HEIGHT=256`,
+      opacity: 0.85,
+    }),
+    visible
+  );
 }
 
 /**
- * Adds a single combined raster layer built from all FKB layers inside
- * the "Vei" group of the Geonorge grunnkart WMS:
- * fkb_veg, fkb_vegavgrensning, fkb_vegavgrensning_sub, fkb_bru,
- * fkb_vegbru, fkb_vegavgrensningbru, fkb_bane, fkb_baneitunnel, fkb_lufthavn.
- *
- * All layers are passed as a comma-separated LAYERS value in a single WMS
- * request so the server composites them and the frontend handles one source.
- * @param map     The MapLibre map instance
- * @param visible Whether the layer starts visible (default false)
+ * Wrapper function to add the Geonorge FKB Vei WMS layer to the map
  */
 export function AddFKBVeiLayer(map: MaplibreGL.Map, visible: boolean = false): void {
-  const sourceId = 'geonorge-fkb-vei';
-  const layerId  = 'geonorge-fkb-vei-layer';
-  const visibility = visible ? 'visible' : 'none';
-
-  const tileUrl =
-    `${WMS_PROXY}/5?url=${encodeURIComponent(GEONORGE_GRUNNKART_BASE_URL)}&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap` +
-    `&LAYERS=${encodeURIComponent(GEONORGE_FKB_VEI_LAYERS)}&STYLES=` +
-    `&FORMAT=image/png&TRANSPARENT=true` +
-    `&CRS=EPSG:3857` +
-    `&BBOX={bbox-epsg-3857}&WIDTH=256&HEIGHT=256`;
-
-  map.addSource(sourceId, {
-    type: 'raster',
-    tiles: [tileUrl],
-    tileSize: 256,
-  });
-
-  map.addLayer({
-    id: layerId,
-    type: 'raster',
-    source: sourceId,
-    paint: { 'raster-opacity': 0.9 },
-    layout: { visibility },
-  });
-
-  registerLayer(layerId, 'FKB Vei', visible, map);
+  addWmsLayers(
+    map,
+    [{
+      name: 'fkb',
+      title: 'FKB Vei',
+    }],
+    () => ({
+      sourceId: 'geonorge-fkb-vei',
+      layerId: 'geonorge-fkb-vei-layer',
+      label: 'FKB Vei',
+      tileUrl:
+        `${WMS_PROXY}/5?url=${encodeURIComponent(GEONORGE_GRUNNKART_BASE_URL)}&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap` +
+        `&LAYERS=${encodeURIComponent(GEONORGE_FKB_VEI_LAYERS)}&STYLES=` +
+        `&FORMAT=image/png&TRANSPARENT=true` +
+        `&CRS=EPSG:3857` +
+        `&BBOX={bbox-epsg-3857}&WIDTH=256&HEIGHT=256`,
+      opacity: 0.9,
+    }),
+    visible
+  );
 }
 
 /**
@@ -418,10 +404,8 @@ function calculateBounds(coordinates: [number, number][]): { minLng: number; max
 }
 
 /**
- * Adds the shortest path layer to the map with a green line.
- * Removes any existing shortest path layer/source first.
- * Automatically fits the map bounds to show the entire path.
- * Enables the shelter layer for the destination county.
+ * Adds the shortest path layer to the map with a green line. Removes any existing shortest path layer/source first.
+ * Automatically fits the map bounds to show the entire path. Enables the shelter layer for the destination county.
  * @param map The MapLibre map instance
  * @param coordinates Array of [lng, lat] coordinates forming the path
  * @param destinationShelterFylkeId The fylke ID where the shelter is located (optional)

--- a/App/frontend/src/layer.ts
+++ b/App/frontend/src/layer.ts
@@ -79,40 +79,63 @@ const DSB_WMS_LAYERS: { name: string; title: string }[] = [
   { name: 'layer_443', title: 'Nødnett dekning kjøretøymontert' },
 ];
 
+// Helper function to close both dropdowns
+function closeAllDropdowns() {
+  layersMenu?.classList.remove('open');
+  stylesMenu?.classList.remove('open');
+  overlay?.classList.remove('dropdown-open');
+}
+
+// Helper function to open a specific dropdown
+function openDropdown(menu: HTMLElement | null, toggle: HTMLElement | null) {
+  if (!menu || !overlay) return;
+
+  // Close the other menu
+  if (menu === layersMenu) {
+    stylesMenu?.classList.remove('open');
+  } else {
+    layersMenu?.classList.remove('open');
+  }
+
+  // Open the selected menu
+  menu.classList.add('open');
+  overlay.classList.add('dropdown-open');
+
+  // Align dropdown to span the full overlay width
+  const overlayRect = overlay.getBoundingClientRect();
+  menu.style.top = overlayRect.bottom + 'px';
+  menu.style.left = overlayRect.left + 'px';
+  menu.style.width = overlayRect.width + 'px';
+}
+
 // Open / close the dropdown when clicking the toggle button
 const overlay = document.querySelector('.map-overlay') as HTMLElement | null;
 layersToggle?.addEventListener('click', (e) => {
   e.stopPropagation();
-  layersMenu?.classList.toggle('open');
-  overlay?.classList.toggle('dropdown-open');
-  // Align dropdown to span the full overlay width
-  if (layersMenu?.classList.contains('open') && overlay) {
-    const overlayRect = overlay.getBoundingClientRect();
-    layersMenu.style.top = overlayRect.bottom + 'px';
-    layersMenu.style.left = overlayRect.left + 'px';
-    layersMenu.style.width = overlayRect.width + 'px';
+  const isOpen = layersMenu?.classList.contains('open');
+  closeAllDropdowns();
+  if (!isOpen) {
+    openDropdown(layersMenu, layersToggle);
   }
 });
+
 document.addEventListener('click', () => {
-  layersMenu?.classList.remove('open');
-  overlay?.classList.remove('dropdown-open');
+  closeAllDropdowns();
 });
+
 // Prevent clicks inside the menu from closing it
 layersMenu?.addEventListener('click', (e) => e.stopPropagation());
 
 // Open / close the styles dropdown when clicking the toggle button
 stylesToggle?.addEventListener('click', (e) => {
   e.stopPropagation();
-  stylesMenu?.classList.toggle('open');
-  overlay?.classList.toggle('dropdown-open');
-  // Align dropdown to span the full overlay width
-  if (stylesMenu?.classList.contains('open') && overlay) {
-    const overlayRect = overlay.getBoundingClientRect();
-    stylesMenu.style.top = overlayRect.bottom + 'px';
-    stylesMenu.style.left = overlayRect.left + 'px';
-    stylesMenu.style.width = overlayRect.width + 'px';
+  const isOpen = stylesMenu?.classList.contains('open');
+  closeAllDropdowns();
+  if (!isOpen) {
+    openDropdown(stylesMenu, stylesToggle);
   }
 });
+
 // Prevent clicks inside the styles menu from closing it
 stylesMenu?.addEventListener('click', (e) => e.stopPropagation());
 
@@ -508,4 +531,3 @@ export function isStyleLayer(layerId: string): boolean {
 export function getStyleLayers(): string[] {
   return Array.from(styleLayers);
 }
-

--- a/App/frontend/src/layer.ts
+++ b/App/frontend/src/layer.ts
@@ -3,15 +3,7 @@ import {
   layerCheckboxes,
   registerLayer,
 } from './layerControl.js';
-
-declare global {
-  interface Window {
-    // The global injected by the CDN; optional because it may not be present in some environments
-    maplibregl?: typeof MaplibreGL;
-    // Exposed for debugging
-    map?: MaplibreGL.Map;
-  }
-}
+import { WmsRasterLayerConfig, ShelterFeature, ShelterFylkeId, MapBounds } from './interfaces.js';
 
 const maplibregl = window.maplibregl;
 
@@ -69,21 +61,6 @@ const DSB_WMS_LAYERS: { name: string; title: string }[] = [
   { name: 'layer_443', title: 'Nødnett dekning kjøretøymontert' },
 ];
 
-interface WmsRasterLayerConfig {
-  sourceId: string;
-  layerId: string;
-  label: string;
-  tileUrl: string;
-  opacity?: number;
-}
-
-/**
- * Generic function to add WMS layers from a configuration array
- * @param map The MapLibre map instance
- * @param layers Array of layer configurations with name and title
- * @param configBuilder Function that builds the tile URL and layer config from a layer
- * @param visible Whether the layers start visible
- */
 function addWmsLayers<T extends { name: string; title: string }>(
   map: MaplibreGL.Map,
   layers: T[],
@@ -262,13 +239,6 @@ function calculateBounds(coordinates: [number, number][]): { minLng: number; max
  * @param destinationShelterFylkeId The fylke ID where the shelter is located (optional)
  * @param shelterFeature The shelter feature to display popup for (optional)
  */
-interface ShelterFeatureProperties {
-  fylkeId: number;
-  [key: string]: unknown;
-}
-
-type ShelterFeature = GeoJSON.Feature<GeoJSON.Point, ShelterFeatureProperties>;
-type ShelterFylkeId = ShelterFeatureProperties['fylkeId'];
 
 export function AddShortestPathLayer(
   map: MaplibreGL.Map,

--- a/App/frontend/src/layerControl.ts
+++ b/App/frontend/src/layerControl.ts
@@ -1,0 +1,144 @@
+﻿import type * as MaplibreGL from "maplibre-gl";
+
+const layersToggle = document.getElementById('layers-toggle');
+const layersMenu   = document.getElementById('layers-menu');
+const stylesToggle = document.getElementById('styles-toggle');
+const stylesMenu   = document.getElementById('styles-menu');
+const overlay      = document.querySelector('.map-overlay') as HTMLElement | null;
+
+//Tracks enabled layers
+export const layerCheckboxes = new Map<string, HTMLInputElement>();
+
+/**
+ * Helper function to close both dropdowns
+ */
+export function closeAllDropdowns(): void {
+  layersMenu?.classList.remove('open');
+  stylesMenu?.classList.remove('open');
+  overlay?.classList.remove('dropdown-open');
+}
+
+/**
+ * Helper function to open a specific dropdown
+ */
+export function openDropdown(menu: HTMLElement | null, toggle: HTMLElement | null): void {
+  if (!menu || !overlay) return;
+
+  // Close the other menu
+  if (menu === layersMenu) {
+    stylesMenu?.classList.remove('open');
+  } else {
+    layersMenu?.classList.remove('open');
+  }
+
+  menu.classList.add('open');
+  overlay.classList.add('dropdown-open');
+
+  const overlayRect = overlay.getBoundingClientRect();
+  menu.style.top = overlayRect.bottom + 'px';
+  menu.style.left = overlayRect.left + 'px';
+  menu.style.width = overlayRect.width + 'px';
+}
+
+/**
+ * Initialize dropdown menu event listeners
+ */
+export function initializeDropdownMenus(): void {
+  layersToggle?.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const isOpen = layersMenu?.classList.contains('open');
+    closeAllDropdowns();
+    if (!isOpen) {
+      openDropdown(layersMenu, layersToggle);
+    }
+  });
+
+  stylesToggle?.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const isOpen = stylesMenu?.classList.contains('open');
+    closeAllDropdowns();
+    if (!isOpen) {
+      openDropdown(stylesMenu, stylesToggle);
+    }
+  });
+
+  document.addEventListener('click', () => {
+    closeAllDropdowns();
+  });
+
+  // Prevent clicks inside the menus from closing them
+  layersMenu?.addEventListener('click', (e) => e.stopPropagation());
+  stylesMenu?.addEventListener('click', (e) => e.stopPropagation());
+}
+
+/**
+ * Register a map layer in the Layers dropdown so the user can toggle it.
+ * @param layerId The MapLibre layer id to toggle visibility for.
+ * @param label Human-readable label shown in the menu.
+ * @param visible Whether the layer starts visible (default true).
+ * @param map The map to add the layer to
+ */
+export function registerLayer(layerId: string, label: string, visible: boolean, map: MaplibreGL.Map): void {
+  if (!layersMenu) return;
+
+  // Remove the "no layers" placeholder if present
+  const empty = layersMenu.querySelector('.dropdown-empty');
+  if (empty) empty.remove();
+
+  const item = document.createElement('label');
+  item.className = 'dropdown-item prevent-select';
+
+  const cb = document.createElement('input');
+  cb.type = 'checkbox';
+  cb.checked = visible;
+
+  cb.addEventListener('change', () => {
+    map.setLayoutProperty(layerId, 'visibility', cb.checked ? 'visible' : 'none');
+  });
+
+  const span = document.createElement('span');
+  span.textContent = label;
+
+  item.appendChild(cb);
+  item.appendChild(span);
+  layersMenu.appendChild(item);
+
+  layerCheckboxes.set(layerId, cb);
+}
+
+/**
+ * Register a style layer in the Styles dropdown menu so the user can toggle it.
+ * @param styleId The style id (as used in registerStyle)
+ * @param label Human-readable label shown in the menu
+ * @param visible Whether the layer starts visible (default false)
+ * @param map The map instance
+ */
+export function registerStyleInMenu(styleId: string, label: string, visible: boolean, map: MaplibreGL.Map): void {
+  if (!stylesMenu) return;
+
+  // Remove the "no styles" placeholder if present
+  const empty = stylesMenu.querySelector('.dropdown-empty');
+  if (empty) empty.remove();
+
+  const layerId = `${styleId}-layer`;
+
+  const item = document.createElement('label');
+  item.className = 'dropdown-item prevent-select';
+
+  const cb = document.createElement('input');
+  cb.type = 'checkbox';
+  cb.checked = visible;
+
+  cb.addEventListener('change', () => {
+    if (map.getLayer(layerId)) {
+      map.setLayoutProperty(layerId, 'visibility', cb.checked ? 'visible' : 'none');
+    }
+  });
+
+  const span = document.createElement('span');
+  span.textContent = label;
+
+  item.appendChild(cb);
+  item.appendChild(span);
+  stylesMenu.appendChild(item);
+}

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -28,7 +28,7 @@ if (!maplibregl) {
   // Create a local `map` variable so TypeScript knows it's defined when we call methods on it.
   const map = new maplibregl.Map({
     container: 'map' as string,
-    style: getMapStyle('default'),
+    style: getMapStyle('positron'),
     center: [8.0, 59.0] as LngLatLike,
     zoom: 2 as number,
   });
@@ -99,6 +99,34 @@ if (!maplibregl) {
       type: 'globe' as string,
     });
 
+    // Add OSM raster layer on top (will fade in when zoomed in)
+    if (!map.getSource('osm-raster')) {
+      map.addSource('osm-raster', {
+        type: 'raster',
+        tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+        tileSize: 256,
+        attribution: '© OpenStreetMap contributors',
+      });
+    }
+
+    //Todo: hardcoded fix this
+    if (!map.getLayer('osm-raster-layer')) {
+      map.addLayer({
+        id: 'osm-raster-layer',
+        type: 'raster',
+        source: 'osm-raster',
+        paint: {
+          'raster-opacity': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            6, 0,
+            10, 1
+          ]
+        }
+      });
+    }
+
     // Stars layer
     import("./starsLayer.js").then(({ createStarsLayer }) => {
       try {
@@ -151,7 +179,6 @@ if (!maplibregl) {
       return v1 + (v2 - v1) * ((zoom - z1) / (z2 - z1));
     }
 
-    //fade light intensity over zoom range so brightness fades consistently with zoom level
     function updateLightForZoom() {
       const z : number = map.getZoom();
       const intensity : number = lerpAtZoom(z, FADE_ZOOM_START, LIGHT_INTENSITY_MAX, FADE_ZOOM_END, 0);
@@ -166,7 +193,6 @@ if (!maplibregl) {
     updateLightForZoom(); //set initial light
     map.on('zoom', updateLightForZoom);
 
-    // Set sky – atmosphere-blend fades out/in-step with the light intensity
     map.setSky({
       'atmosphere-blend': [
         'interpolate',
@@ -178,75 +204,76 @@ if (!maplibregl) {
       ],
     });
 
-    //dark style for on globe view, to properly show the contrast between day and night
-    const darkPaint: [string, string, string, string][] = [
+    const darkPaints: [string, string, string, string][] = [
       ['background',          'background-color', 'rgb(11, 11, 15)',    'rgb(242, 243, 240)'],
-      ['water',               'fill-color',       'rgb(5, 8, 18)',    'rgb(194, 200, 202)'],
-      ['water',               'fill-outline-color','rgb(3, 5, 14)',    'rgb(194, 200, 202)'],
-      ['park',                'fill-color',       'rgb(8, 12, 8)',    'rgb(230, 233, 229)'],
-      ['landcover_ice_shelf', 'fill-color',       'rgb(12, 12, 14)',  'hsl(0, 0%, 98%)'],
-      ['landcover_glacier',   'fill-color',       'rgb(12, 12, 14)',  'hsl(0, 0%, 98%)'],
-      ['landuse_residential', 'fill-color',       'rgb(10, 10, 12)',  'rgb(234, 234, 230)'],
-      ['landcover_wood',      'fill-color',       'rgb(6, 10, 6)',    'rgb(230, 233, 229)'],
-      ['building',            'fill-color',       'rgb(14, 14, 16)',  'rgb(234, 234, 229)'],
-      ['building',            'fill-outline-color','rgb(10, 10, 12)', 'rgb(219, 219, 218)'],
-      ['waterway',            'line-color',       'rgb(5, 8, 18)',    'rgb(194, 200, 202)'],
+      ['water',               'fill-color',       'rgb(5, 8, 18)',      'rgb(194, 200, 202)'],
+      ['park',                'fill-color',       'rgb(8, 12, 8)',      'rgb(230, 233, 229)'],
+      ['landcover_ice_shelf', 'fill-color',       'rgb(12, 12, 14)',    'hsl(0, 0%, 98%)'],
+      ['landcover_glacier',   'fill-color',       'rgb(12, 12, 14)',    'hsl(0, 0%, 98%)'],
+      ['landuse_residential', 'fill-color',       'rgb(10, 10, 12)',    'rgb(234, 234, 230)'],
+      ['landcover_wood',      'fill-color',       'rgb(6, 10, 6)',      'rgb(230, 233, 229)'],
+      ['building',            'fill-color',       'rgb(14, 14, 16)',    'rgb(234, 234, 229)'],
+      ['building',            'fill-outline-color','rgb(10, 10, 12)',   'rgb(219, 219, 218)'],
+      ['waterway',            'line-color',       'rgb(5, 8, 18)',      'rgb(194, 200, 202)'],
       ['boundary_2',          'line-color',       'rgb(5, 5, 8)',       'hsl(0, 0%, 70%)'],
       ['boundary_3',          'line-color',       'rgb(5, 5, 8)',       'hsl(0, 0%, 70%)'],
       ['boundary_disputed',   'line-color',       'rgb(5, 5, 8)',       'hsl(0, 0%, 70%)'],
-      ['label_country_1',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
-      ['label_country_1',     'text-halo-color',  'rgb(2, 2, 4)',      '#ffffff'],
-      ['label_country_2',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
-      ['label_country_2',     'text-halo-color',  'rgb(2, 2, 4)',      '#ffffff'],
-      ['label_country_3',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
-      ['label_country_3',     'text-halo-color',  'rgb(2, 2, 4)',      '#ffffff'],
-      ['label_city',          'text-color',       'rgb(35, 35, 45)',    '#000000'],
-      ['label_city',          'text-halo-color',  'rgb(2, 2, 4)',      '#ffffff'],
-      ['label_city_capital',  'text-color',       'rgb(35, 35, 45)',    '#000000'],
-      ['label_city_capital',  'text-halo-color',  'rgb(2, 2, 4)',      '#ffffff'],
-      ['label_town',          'text-color',       'rgb(35, 35, 45)',    '#000000'],
-      ['label_town',          'text-halo-color',  'rgb(2, 2, 4)',      '#ffffff'],
-      ['label_state',         'text-color',       'rgb(35, 35, 45)',    '#333333'],
-      ['label_state',         'text-halo-color',  'rgb(2, 2, 4)',      '#ffffff'],
-      ['waterway_line_label',   'text-halo-color', 'rgba(2, 2, 4, 0.7)',  'rgba(255, 255, 255, 0.7)'],
-      ['waterway_line_label',   'text-color',      'rgb(20, 25, 40)',     'hsl(0, 0%, 66%)'],
-      ['water_name_point_label','text-halo-color',  'rgba(2, 2, 4, 0.7)', 'rgba(255, 255, 255, 0.7)'],
-      ['water_name_point_label','text-color',       'rgb(15, 20, 45)',    '#495e91'],
-      ['water_name_line_label', 'text-halo-color',  'rgba(2, 2, 4, 0.7)', 'rgba(255, 255, 255, 0.7)'],
-      ['water_name_line_label', 'text-color',       'rgb(15, 20, 45)',    '#495e91'],
-      ['tunnel_motorway_casing',        'line-color', 'rgb(10, 10, 14)',  'rgb(213, 213, 213)'],
-      ['highway_major_casing',          'line-color', 'rgb(10, 10, 14)',  'rgb(213, 213, 213)'],
-      ['highway_motorway_casing',       'line-color', 'rgb(10, 10, 14)',  'rgb(213, 213, 213)'],
-      ['highway_motorway_bridge_casing','line-color', 'rgb(10, 10, 14)',  'rgb(213, 213, 213)'],
-      ['tunnel_motorway_inner',         'line-color', 'rgb(12, 12, 16)',  'rgb(234, 234, 234)'],
-      ['highway_major_inner',           'line-color', 'rgb(12, 12, 16)',  '#ffffff'],
-      ['highway_motorway_inner',        'line-color', 'rgb(12, 12, 16)',  '#ffffff'],
-      ['highway_motorway_bridge_inner', 'line-color', 'rgb(12, 12, 16)',  '#ffffff'],
+      ['tunnel_motorway_casing',        'line-color', 'rgb(10, 10, 14)',    'rgb(213, 213, 213)'],
+      ['tunnel_motorway_inner',         'line-color', 'rgb(12, 12, 16)',    'rgb(234, 234, 234)'],
+      ['highway_path',                  'line-color', 'rgb(12, 12, 16)',    'rgb(234, 234, 234)'],
+      ['highway_minor',                 'line-color', 'rgb(10, 10, 14)',    'hsl(0, 0%, 88%)'],
+      ['highway_major_casing',          'line-color', 'rgb(10, 10, 14)',    'rgb(213, 213, 213)'],
+      ['highway_major_inner',           'line-color', 'rgb(12, 12, 16)',    '#ffffff'],
       ['highway_major_subtle',          'line-color', 'rgba(10,10,14,0.69)', 'hsla(0,0%,85%,0.69)'],
+      ['highway_motorway_casing',       'line-color', 'rgb(10, 10, 14)',    'rgb(213, 213, 213)'],
+      ['highway_motorway_inner',        'line-color', 'rgb(12, 12, 16)',    '#ffffff'],
       ['highway_motorway_subtle',       'line-color', 'rgba(10,10,14,0.53)', 'hsla(0,0%,85%,0.53)'],
-      ['highway_path',                  'line-color', 'rgb(12, 12, 16)',  'rgb(234, 234, 234)'],
-      ['highway_minor',                 'line-color', 'rgb(10, 10, 14)',  'hsl(0, 0%, 88%)'],
-      ['road_area_pier',                'fill-color', 'rgb(8, 8, 12)',    'rgb(242, 243, 240)'],
-      ['road_pier',                     'line-color', 'rgb(8, 8, 12)',    'rgb(242, 243, 240)'],
-      ['railway',                       'line-color', 'rgb(10, 10, 14)',  '#dddddd'],
-      ['railway_dashline',              'line-color', 'rgb(12, 12, 16)',  '#fafafa'],
-      ['railway_transit',               'line-color', 'rgb(10, 10, 14)',  '#dddddd'],
-      ['railway_transit_dashline',      'line-color', 'rgb(12, 12, 16)',  '#fafafa'],
-      ['railway_service',               'line-color', 'rgb(10, 10, 14)',  '#dddddd'],
-      ['railway_service_dashline',      'line-color', 'rgb(12, 12, 16)',  '#fafafa'],
+      ['highway_motorway_bridge_casing','line-color', 'rgb(10, 10, 14)',    'rgb(213, 213, 213)'],
+      ['highway_motorway_bridge_inner', 'line-color', 'rgb(12, 12, 16)',    '#ffffff'],
+      ['road_area_pier',                'fill-color', 'rgb(8, 8, 12)',      'rgb(242, 243, 240)'],
+      ['road_pier',                     'line-color', 'rgb(8, 8, 12)',      'rgb(242, 243, 240)'],
+      ['railway',                       'line-color', 'rgb(10, 10, 14)',    '#dddddd'],
+      ['railway_dashline',              'line-color', 'rgb(12, 12, 16)',    '#fafafa'],
+      ['railway_transit',               'line-color', 'rgb(10, 10, 14)',    '#dddddd'],
+      ['railway_transit_dashline',      'line-color', 'rgb(12, 12, 16)',    '#fafafa'],
+      ['railway_service',               'line-color', 'rgb(10, 10, 14)',    '#dddddd'],
+      ['railway_service_dashline',      'line-color', 'rgb(12, 12, 16)',    '#fafafa'],
+      ['label_country_1',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
+      ['label_country_1',     'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
+      ['label_country_2',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
+      ['label_country_2',     'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
+      ['label_country_3',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
+      ['label_country_3',     'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
+      ['label_city',          'text-color',       'rgb(35, 35, 45)',    '#000000'],
+      ['label_city',          'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
+      ['label_city_capital',  'text-color',       'rgb(35, 35, 45)',    '#000000'],
+      ['label_city_capital',  'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
+      ['label_town',          'text-color',       'rgb(35, 35, 45)',    '#000000'],
+      ['label_town',          'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
+      ['label_state',         'text-color',       'rgb(35, 35, 45)',    '#333333'],
+      ['label_state',         'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
+      ['waterway_line_label',   'text-halo-color', 'rgba(2, 2, 4, 0.7)',      'rgba(255, 255, 255, 0.7)'],
+      ['waterway_line_label',   'text-color',      'rgb(20, 25, 40)',         'hsl(0, 0%, 66%)'],
+      ['water_name_point_label','text-halo-color', 'rgba(2, 2, 4, 0.7)',      'rgba(255, 255, 255, 0.7)'],
+      ['water_name_point_label','text-color',      'rgb(15, 20, 45)',         '#495e91'],
+      ['water_name_line_label', 'text-halo-color', 'rgba(2, 2, 4, 0.7)',      'rgba(255, 255, 255, 0.7)'],
+      ['water_name_line_label', 'text-color',      'rgb(15, 20, 45)',         '#495e91'],
     ];
-    for (const entry of darkPaint) {
-      if (map.getLayer(entry[0])) {
-        map.setPaintProperty(entry[0], entry[1], [
+
+    // Apply the dark-to-light color transitions for each layer
+    darkPaints.forEach(([layerId, property, darkColor, lightColor]) => {
+      const layer = map.getLayer(layerId);
+      if (layer) {
+        map.setPaintProperty(layerId, property, [
           'interpolate',
           ['linear'],
           ['zoom'],
-          0, entry[2],
-          FADE_ZOOM_START, entry[2],
-          FADE_ZOOM_END, entry[3],
+          0, darkColor,
+          FADE_ZOOM_START, darkColor,
+          FADE_ZOOM_END, lightColor,
         ]);
       }
-    }
+    });
     const fylkeIds = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
     (async () => {
       await AddShelterLayerGeospatial(map, fylkeIds);

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -7,8 +7,9 @@ import {
 } from "maplibre-gl";
 import { registerKonamiCode } from './middleEarth.js';
 import {AddShelterLayerGeospatial, AddDSBWmsLayers, AddVannOgVassdragLayers, AddFKBVeiLayer} from './layer.js'
+import {registerStyle} from "./mapStyles.js";
 import { calculateAndDisplayPath, clearPath } from './shortestPath.js'
-import { getMapStyle } from './mapStyles.js';
+import { getMapStyle, GLOBE_FADE_CONFIG, DARK_PAINTS } from './mapStyles.js';
 
 declare global {
   interface Window {
@@ -40,15 +41,13 @@ if (!maplibregl) {
     positionOptions: { enableHighAccuracy: true as boolean },
     trackUserLocation: true as boolean,
     showAccuracyCircle: true as boolean,
-
   });
   map.addControl(geolocate, 'top-right');
 
   map.on('load', () => {
     try {
       geolocate?.trigger();
-    }
-    catch (err) {
+    } catch (err) {
       console.warn('Geolocate trigger failed:', err);
     }
   });
@@ -66,7 +65,7 @@ if (!maplibregl) {
       let lat: number | undefined;
       let lng: number | undefined;
 
-      //Override geolocation, oslo: window.debugGeoLocation = {lat: 59.9139, lng: 10.7522};
+      // Override geolocation for testing (e.g., oslo: window.debugGeoLocation = {lat: 59.9139, lng: 10.7522})
       if (window.debugGeoLocation) {
         lat = window.debugGeoLocation.lat;
         lng = window.debugGeoLocation.lng;
@@ -99,33 +98,16 @@ if (!maplibregl) {
       type: 'globe' as string,
     });
 
-    // Add OSM raster layer on top (will fade in when zoomed in)
-    if (!map.getSource('osm-raster')) {
-      map.addSource('osm-raster', {
-        type: 'raster',
-        tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
-        tileSize: 256,
-        attribution: '© OpenStreetMap contributors',
-      });
-    }
-
-    //Todo: hardcoded fix this
-    if (!map.getLayer('osm-raster-layer')) {
-      map.addLayer({
-        id: 'osm-raster-layer',
-        type: 'raster',
-        source: 'osm-raster',
-        paint: {
-          'raster-opacity': [
-            'interpolate',
-            ['linear'],
-            ['zoom'],
-            6, 0,
-            10, 1
-          ]
-        }
-      });
-    }
+    // Register OSM raster layer that fades in when zoomed in
+    registerStyle(map, {
+      id: 'osm-raster',
+      tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+      type: 'raster',
+      tileSize: 256,
+      attribution: '© OpenStreetMap contributors',
+      fadeZoomStart: 6,
+      fadeZoomEnd: 10,
+    });
 
     // Stars layer
     import("./starsLayer.js").then(({ createStarsLayer }) => {
@@ -136,8 +118,8 @@ if (!maplibregl) {
           density: 0.55 as number,
         });
         if (!map.getLayer('stars')) {
-          const layers : LayerSpecification[] = map.getStyle().layers;
-          const firstLayerId : string | undefined = layers && layers.length > 0 ? layers[0].id : undefined;
+          const layers: LayerSpecification[] = map.getStyle().layers;
+          const firstLayerId: string | undefined = layers && layers.length > 0 ? layers[0].id : undefined;
           map.addLayer(starsLayer as AddLayerObject, firstLayerId);
         }
       } catch (err) {
@@ -147,22 +129,14 @@ if (!maplibregl) {
       console.warn('Failed to load starsLayer module:', err);
     });
 
-    const LIGHT_THETA_DEG : number = -37;
-    const LIGHT_PHI_DEG : number = 4;
-    const LIGHT_RADIAL_DIST : number = 300000.0;
-    const LIGHT_COLOR : string = '#ffffff';
-
-    // Maximum light intensity when fully zoomed out (globe view)
-    // Maximum atmosphere-blend when fully zoomed out (1.0 = full atmosphere glow)
-    const LIGHT_INTENSITY_MAX : number = 1.0 as number;
-    const ATMOSPHERE_BLEND_MAX : number = 1.0 as number;
-
-    // Zoom range over which globe effects (light, atmosphere, dark colors)
-    // are fully active vs. fully faded out to the normal map style.
-    // At or below FADE_ZOOM_START everything is in "globe/dark" mode.
-    // At or above FADE_ZOOM_END everything matches the original bright style.
-    const FADE_ZOOM_START : number = 6;
-    const FADE_ZOOM_END : number = 10;
+    const LIGHT_THETA_DEG: number = GLOBE_FADE_CONFIG.LIGHT_THETA_DEG;
+    const LIGHT_PHI_DEG: number = GLOBE_FADE_CONFIG.LIGHT_PHI_DEG;
+    const LIGHT_RADIAL_DIST: number = GLOBE_FADE_CONFIG.LIGHT_RADIAL_DIST;
+    const LIGHT_COLOR: string = GLOBE_FADE_CONFIG.LIGHT_COLOR;
+    const LIGHT_INTENSITY_MAX: number = GLOBE_FADE_CONFIG.LIGHT_INTENSITY_MAX;
+    const ATMOSPHERE_BLEND_MAX: number = GLOBE_FADE_CONFIG.ATMOSPHERE_BLEND_MAX;
+    const FADE_ZOOM_START: number = GLOBE_FADE_CONFIG.FADE_ZOOM_START;
+    const FADE_ZOOM_END: number = GLOBE_FADE_CONFIG.FADE_ZOOM_END;
 
     // Calculate light position (radial distance, azimuthal angle, polar angle)
     const p = (Math.acos(Math.cos((LIGHT_THETA_DEG / 180 as number + 1 as number) * Math.PI)
@@ -172,7 +146,7 @@ if (!maplibregl) {
       Math.sin((LIGHT_THETA_DEG / 180 as number + 1 as number) * Math.PI) * Math.cos((LIGHT_PHI_DEG / 180 as number) * Math.PI)
     ) / Math.PI) * 180 as number;
 
-    //interpolate a value between two zoom stops
+    // Interpolate a value between two zoom stops
     function lerpAtZoom(zoom: number, z1: number, v1: number, z2: number, v2: number): number {
       if (zoom <= z1) return v1;
       if (zoom >= z2) return v2;
@@ -180,8 +154,8 @@ if (!maplibregl) {
     }
 
     function updateLightForZoom() {
-      const z : number = map.getZoom();
-      const intensity : number = lerpAtZoom(z, FADE_ZOOM_START, LIGHT_INTENSITY_MAX, FADE_ZOOM_END, 0);
+      const z: number = map.getZoom();
+      const intensity: number = lerpAtZoom(z, FADE_ZOOM_START, LIGHT_INTENSITY_MAX, FADE_ZOOM_END, 0);
       map.setLight({
         anchor: 'map' as PropertyValueSpecification<"map">,
         position: [LIGHT_RADIAL_DIST, a, p],
@@ -190,7 +164,7 @@ if (!maplibregl) {
       });
     }
 
-    updateLightForZoom(); //set initial light
+    updateLightForZoom(); // Set initial light
     map.on('zoom', updateLightForZoom);
 
     map.setSky({
@@ -204,64 +178,8 @@ if (!maplibregl) {
       ],
     });
 
-    const darkPaints: [string, string, string, string][] = [
-      ['background',          'background-color', 'rgb(11, 11, 15)',    'rgb(242, 243, 240)'],
-      ['water',               'fill-color',       'rgb(5, 8, 18)',      'rgb(194, 200, 202)'],
-      ['park',                'fill-color',       'rgb(8, 12, 8)',      'rgb(230, 233, 229)'],
-      ['landcover_ice_shelf', 'fill-color',       'rgb(12, 12, 14)',    'hsl(0, 0%, 98%)'],
-      ['landcover_glacier',   'fill-color',       'rgb(12, 12, 14)',    'hsl(0, 0%, 98%)'],
-      ['landuse_residential', 'fill-color',       'rgb(10, 10, 12)',    'rgb(234, 234, 230)'],
-      ['landcover_wood',      'fill-color',       'rgb(6, 10, 6)',      'rgb(230, 233, 229)'],
-      ['building',            'fill-color',       'rgb(14, 14, 16)',    'rgb(234, 234, 229)'],
-      ['building',            'fill-outline-color','rgb(10, 10, 12)',   'rgb(219, 219, 218)'],
-      ['waterway',            'line-color',       'rgb(5, 8, 18)',      'rgb(194, 200, 202)'],
-      ['boundary_2',          'line-color',       'rgb(5, 5, 8)',       'hsl(0, 0%, 70%)'],
-      ['boundary_3',          'line-color',       'rgb(5, 5, 8)',       'hsl(0, 0%, 70%)'],
-      ['boundary_disputed',   'line-color',       'rgb(5, 5, 8)',       'hsl(0, 0%, 70%)'],
-      ['tunnel_motorway_casing',        'line-color', 'rgb(10, 10, 14)',    'rgb(213, 213, 213)'],
-      ['tunnel_motorway_inner',         'line-color', 'rgb(12, 12, 16)',    'rgb(234, 234, 234)'],
-      ['highway_path',                  'line-color', 'rgb(12, 12, 16)',    'rgb(234, 234, 234)'],
-      ['highway_minor',                 'line-color', 'rgb(10, 10, 14)',    'hsl(0, 0%, 88%)'],
-      ['highway_major_casing',          'line-color', 'rgb(10, 10, 14)',    'rgb(213, 213, 213)'],
-      ['highway_major_inner',           'line-color', 'rgb(12, 12, 16)',    '#ffffff'],
-      ['highway_major_subtle',          'line-color', 'rgba(10,10,14,0.69)', 'hsla(0,0%,85%,0.69)'],
-      ['highway_motorway_casing',       'line-color', 'rgb(10, 10, 14)',    'rgb(213, 213, 213)'],
-      ['highway_motorway_inner',        'line-color', 'rgb(12, 12, 16)',    '#ffffff'],
-      ['highway_motorway_subtle',       'line-color', 'rgba(10,10,14,0.53)', 'hsla(0,0%,85%,0.53)'],
-      ['highway_motorway_bridge_casing','line-color', 'rgb(10, 10, 14)',    'rgb(213, 213, 213)'],
-      ['highway_motorway_bridge_inner', 'line-color', 'rgb(12, 12, 16)',    '#ffffff'],
-      ['road_area_pier',                'fill-color', 'rgb(8, 8, 12)',      'rgb(242, 243, 240)'],
-      ['road_pier',                     'line-color', 'rgb(8, 8, 12)',      'rgb(242, 243, 240)'],
-      ['railway',                       'line-color', 'rgb(10, 10, 14)',    '#dddddd'],
-      ['railway_dashline',              'line-color', 'rgb(12, 12, 16)',    '#fafafa'],
-      ['railway_transit',               'line-color', 'rgb(10, 10, 14)',    '#dddddd'],
-      ['railway_transit_dashline',      'line-color', 'rgb(12, 12, 16)',    '#fafafa'],
-      ['railway_service',               'line-color', 'rgb(10, 10, 14)',    '#dddddd'],
-      ['railway_service_dashline',      'line-color', 'rgb(12, 12, 16)',    '#fafafa'],
-      ['label_country_1',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
-      ['label_country_1',     'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
-      ['label_country_2',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
-      ['label_country_2',     'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
-      ['label_country_3',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
-      ['label_country_3',     'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
-      ['label_city',          'text-color',       'rgb(35, 35, 45)',    '#000000'],
-      ['label_city',          'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
-      ['label_city_capital',  'text-color',       'rgb(35, 35, 45)',    '#000000'],
-      ['label_city_capital',  'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
-      ['label_town',          'text-color',       'rgb(35, 35, 45)',    '#000000'],
-      ['label_town',          'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
-      ['label_state',         'text-color',       'rgb(35, 35, 45)',    '#333333'],
-      ['label_state',         'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
-      ['waterway_line_label',   'text-halo-color', 'rgba(2, 2, 4, 0.7)',      'rgba(255, 255, 255, 0.7)'],
-      ['waterway_line_label',   'text-color',      'rgb(20, 25, 40)',         'hsl(0, 0%, 66%)'],
-      ['water_name_point_label','text-halo-color', 'rgba(2, 2, 4, 0.7)',      'rgba(255, 255, 255, 0.7)'],
-      ['water_name_point_label','text-color',      'rgb(15, 20, 45)',         '#495e91'],
-      ['water_name_line_label', 'text-halo-color', 'rgba(2, 2, 4, 0.7)',      'rgba(255, 255, 255, 0.7)'],
-      ['water_name_line_label', 'text-color',      'rgb(15, 20, 45)',         '#495e91'],
-    ];
-
-    // Apply the dark-to-light color transitions for each layer
-    darkPaints.forEach(([layerId, property, darkColor, lightColor]) => {
+    // Apply dark-to-light color transitions for each layer
+    DARK_PAINTS.forEach(([layerId, property, darkColor, lightColor]) => {
       const layer = map.getLayer(layerId);
       if (layer) {
         map.setPaintProperty(layerId, property, [
@@ -274,6 +192,8 @@ if (!maplibregl) {
         ]);
       }
     });
+
+    // Load all layers
     const fylkeIds = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
     (async () => {
       await AddShelterLayerGeospatial(map, fylkeIds);
@@ -281,5 +201,5 @@ if (!maplibregl) {
       AddVannOgVassdragLayers(map);
       AddFKBVeiLayer(map);
     })().catch(err => console.error('Error loading layers:', err));
-  }
-)}
+  });
+}

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -1,27 +1,11 @@
-﻿import type * as MaplibreGL from 'maplibre-gl';
-import {
-  AddLayerObject,
-  LayerSpecification,
-  LngLatLike,
-  PropertyValueSpecification
-} from "maplibre-gl";
+﻿import { AddLayerObject, LayerSpecification, LngLatLike, PropertyValueSpecification } from "maplibre-gl";
 import { registerKonamiCode } from './middleEarth.js';
 import {AddShelterLayerGeospatial, AddDSBWmsLayers, AddVannOgVassdragLayers, AddFKBVeiLayer} from './layer.js'
 import {registerStyleInMenu, initializeDropdownMenus} from './layerControl.js'
 import {registerStyle} from "./mapStyles.js";
 import { calculateAndDisplayPath, clearPath } from './shortestPath.js'
 import { getMapStyle, GLOBE_FADE_CONFIG, DARK_PAINTS } from './mapStyles.js';
-
-declare global {
-  interface Window {
-    // The global injected by the CDN; optional because it may not be present in some environments
-    maplibregl?: typeof MaplibreGL;
-    // Exposed for debugging
-    map?: MaplibreGL.Map;
-    // Debug override for geolocation (for testing with DevTools sensor)
-    debugGeoLocation?: { lat: number; lng: number };
-  }
-}
+import './interfaces.js';
 
 const maplibregl = window.maplibregl;
 if (!maplibregl) {

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -6,10 +6,10 @@ import {
   PropertyValueSpecification
 } from "maplibre-gl";
 import { registerKonamiCode } from './middleEarth.js';
-import {AddShelterLayerGeospatial, AddDSBWmsLayers, AddVannOgVassdragLayers, AddFKBVeiLayer} from './layer.js'
+import {AddShelterLayerGeospatial, AddDSBWmsLayers, AddVannOgVassdragLayers, AddFKBVeiLayer, registerStyleLayer, registerStyleInMenu, isStyleLayer, getStyleLayers} from './layer.js'
 import {registerStyle} from "./mapStyles.js";
 import { calculateAndDisplayPath, clearPath } from './shortestPath.js'
-import { getMapStyle, GLOBE_FADE_CONFIG, DARK_PAINTS } from './mapStyles.js';
+import { getMapStyle, GLOBE_FADE_CONFIG, DARK_PAINTS, toggleStyleLayer, isStyleLayerVisible } from './mapStyles.js';
 
 declare global {
   interface Window {
@@ -108,6 +108,9 @@ if (!maplibregl) {
       fadeZoomStart: 6,
       fadeZoomEnd: 10,
     });
+
+    // Add OSM raster layer to the styles menu
+    registerStyleInMenu('osm-raster', 'OpenStreetMap Raster', false, map);
 
     // Stars layer
     import("./starsLayer.js").then(({ createStarsLayer }) => {

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -6,10 +6,11 @@ import {
   PropertyValueSpecification
 } from "maplibre-gl";
 import { registerKonamiCode } from './middleEarth.js';
-import {AddShelterLayerGeospatial, AddDSBWmsLayers, AddVannOgVassdragLayers, AddFKBVeiLayer, registerStyleLayer, registerStyleInMenu, isStyleLayer, getStyleLayers} from './layer.js'
+import {AddShelterLayerGeospatial, AddDSBWmsLayers, AddVannOgVassdragLayers, AddFKBVeiLayer} from './layer.js'
+import {registerStyleInMenu, initializeDropdownMenus} from './layerControl.js'
 import {registerStyle} from "./mapStyles.js";
 import { calculateAndDisplayPath, clearPath } from './shortestPath.js'
-import { getMapStyle, GLOBE_FADE_CONFIG, DARK_PAINTS, toggleStyleLayer, isStyleLayerVisible } from './mapStyles.js';
+import { getMapStyle, GLOBE_FADE_CONFIG, DARK_PAINTS } from './mapStyles.js';
 
 declare global {
   interface Window {
@@ -36,6 +37,7 @@ if (!maplibregl) {
 
   window.map = map;
   registerKonamiCode(map);
+  initializeDropdownMenus();
 
   const geolocate = new maplibregl.GeolocateControl({
     positionOptions: { enableHighAccuracy: true as boolean },

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -8,6 +8,7 @@ import {
 import { registerKonamiCode } from './middleEarth.js';
 import {AddShelterLayerGeospatial, AddDSBWmsLayers, AddVannOgVassdragLayers, AddFKBVeiLayer} from './layer.js'
 import { calculateAndDisplayPath, clearPath } from './shortestPath.js'
+import { getMapStyle } from './mapStyles.js';
 
 declare global {
   interface Window {
@@ -27,7 +28,7 @@ if (!maplibregl) {
   // Create a local `map` variable so TypeScript knows it's defined when we call methods on it.
   const map = new maplibregl.Map({
     container: 'map' as string,
-    style: '../static/style/mapstyle.json' as string,
+    style: getMapStyle('default'),
     center: [8.0, 59.0] as LngLatLike,
     zoom: 2 as number,
   });

--- a/App/frontend/src/mapStyles.ts
+++ b/App/frontend/src/mapStyles.ts
@@ -102,9 +102,6 @@ export const getMapStyle = (styleKey: MapStyleKey = 'default') => {
   return mapStyles[styleKey].style;
 };
 
-export const getMapStyleName = (styleKey: MapStyleKey = 'default') => {
-  return mapStyles[styleKey].name;
-};
 
 /**
  * Registers a tiled layer with the map, including its source.
@@ -168,35 +165,4 @@ export function registerStyle(map: MaplibreGL.Map, options: RegisterStyleOptions
 
     map.addLayer(layerConfig);
   }
-}
-
-/**
- * Toggles a style layer's visibility
- * @param map The MapLibre map instance
- * @param id The style id (as used in registerStyle)
- * @returns The new visibility state (true = visible, false = hidden)
- */
-export function toggleStyleLayer(map: MaplibreGL.Map, id: string): boolean {
-  const layerId = `${id}-layer`;
-  if (map.getLayer(layerId)) {
-    const currentVisibility = map.getLayoutProperty(layerId, 'visibility') as string;
-    const isVisible = currentVisibility !== 'none';
-    map.setLayoutProperty(layerId, 'visibility', isVisible ? 'none' : 'visible');
-    return !isVisible;
-  }
-  return false;
-}
-
-/**
- * Gets the current visibility state of a style layer
- * @param map The MapLibre map instance
- * @param id The style id (as used in registerStyle)
- * @returns true if visible, false if hidden or layer doesn't exist
- */
-export function isStyleLayerVisible(map: MaplibreGL.Map, id: string): boolean {
-  const layerId = `${id}-layer`;
-  const layer = map.getLayer(layerId);
-  if (!layer) return false;
-  const visibility = map.getLayoutProperty(layerId, 'visibility') as string;
-  return visibility !== 'none';
 }

--- a/App/frontend/src/mapStyles.ts
+++ b/App/frontend/src/mapStyles.ts
@@ -1,5 +1,6 @@
 ﻿import type { StyleSpecification } from 'maplibre-gl';
 import type * as MaplibreGL from "maplibre-gl";
+import { RegisterStyleOptions} from './interfaces.js'
 
 export const GLOBE_FADE_CONFIG = {
   LIGHT_THETA_DEG: -37,
@@ -101,23 +102,6 @@ export type MapStyleKey = keyof typeof mapStyles;
 export const getMapStyle = (styleKey: MapStyleKey = 'default') => {
   return mapStyles[styleKey].style;
 };
-
-
-/**
- * Registers a tiled layer with the map, including its source.
- * Supports both raster and vector tile sources with opacity fade control.
- * @param map The MapLibre map instance
- * @param options Configuration for the layer registration
- */
-export interface RegisterStyleOptions {
-  id: string;
-  tiles: string[];
-  type: 'raster' | 'vector';
-  tileSize?: number;
-  attribution?: string;
-  fadeZoomStart?: number;
-  fadeZoomEnd?: number;
-}
 
 export function registerStyle(map: MaplibreGL.Map, options: RegisterStyleOptions): void {
   const {

--- a/App/frontend/src/mapStyles.ts
+++ b/App/frontend/src/mapStyles.ts
@@ -161,6 +161,9 @@ export function registerStyle(map: MaplibreGL.Map, options: RegisterStyleOptions
           ],
         },
       }),
+      layout: {
+        visibility: 'none',
+      },
     } as any;
 
     map.addLayer(layerConfig);

--- a/App/frontend/src/mapStyles.ts
+++ b/App/frontend/src/mapStyles.ts
@@ -1,8 +1,72 @@
-﻿/**
- * Map style configurations for the application
- */
+﻿import type { StyleSpecification } from 'maplibre-gl';
+import type * as MaplibreGL from "maplibre-gl";
 
-import type { StyleSpecification } from 'maplibre-gl';
+export const GLOBE_FADE_CONFIG = {
+  LIGHT_THETA_DEG: -37,
+  LIGHT_PHI_DEG: 4,
+  LIGHT_RADIAL_DIST: 300000.0,
+  LIGHT_COLOR: '#ffffff',
+  LIGHT_INTENSITY_MAX: 1.0,
+  ATMOSPHERE_BLEND_MAX: 1.0,
+  FADE_ZOOM_START: 6,
+  FADE_ZOOM_END: 10,
+} as const;
+
+export const DARK_PAINTS: [string, string, string, string][] = [
+  ['background',          'background-color', 'rgb(11, 11, 15)',    'rgb(242, 243, 240)'],
+  ['water',               'fill-color',       'rgb(5, 8, 18)',      'rgb(194, 200, 202)'],
+  ['park',                'fill-color',       'rgb(8, 12, 8)',      'rgb(230, 233, 229)'],
+  ['landcover_ice_shelf', 'fill-color',       'rgb(12, 12, 14)',    'hsl(0, 0%, 98%)'],
+  ['landcover_glacier',   'fill-color',       'rgb(12, 12, 14)',    'hsl(0, 0%, 98%)'],
+  ['landuse_residential', 'fill-color',       'rgb(10, 10, 12)',    'rgb(234, 234, 230)'],
+  ['landcover_wood',      'fill-color',       'rgb(6, 10, 6)',      'rgb(230, 233, 229)'],
+  ['building',            'fill-color',       'rgb(14, 14, 16)',    'rgb(234, 234, 229)'],
+  ['building',            'fill-outline-color','rgb(10, 10, 12)',   'rgb(219, 219, 218)'],
+  ['waterway',            'line-color',       'rgb(5, 8, 18)',      'rgb(194, 200, 202)'],
+  ['boundary_2',          'line-color',       'rgb(5, 5, 8)',       'hsl(0, 0%, 70%)'],
+  ['boundary_3',          'line-color',       'rgb(5, 5, 8)',       'hsl(0, 0%, 70%)'],
+  ['boundary_disputed',   'line-color',       'rgb(5, 5, 8)',       'hsl(0, 0%, 70%)'],
+  ['tunnel_motorway_casing',        'line-color', 'rgb(10, 10, 14)',    'rgb(213, 213, 213)'],
+  ['tunnel_motorway_inner',         'line-color', 'rgb(12, 12, 16)',    'rgb(234, 234, 234)'],
+  ['highway_path',                  'line-color', 'rgb(12, 12, 16)',    'rgb(234, 234, 234)'],
+  ['highway_minor',                 'line-color', 'rgb(10, 10, 14)',    'hsl(0, 0%, 88%)'],
+  ['highway_major_casing',          'line-color', 'rgb(10, 10, 14)',    'rgb(213, 213, 213)'],
+  ['highway_major_inner',           'line-color', 'rgb(12, 12, 16)',    '#ffffff'],
+  ['highway_major_subtle',          'line-color', 'rgba(10,10,14,0.69)', 'hsla(0,0%,85%,0.69)'],
+  ['highway_motorway_casing',       'line-color', 'rgb(10, 10, 14)',    'rgb(213, 213, 213)'],
+  ['highway_motorway_inner',        'line-color', 'rgb(12, 12, 16)',    '#ffffff'],
+  ['highway_motorway_subtle',       'line-color', 'rgba(10,10,14,0.53)', 'hsla(0,0%,85%,0.53)'],
+  ['highway_motorway_bridge_casing','line-color', 'rgb(10, 10, 14)',    'rgb(213, 213, 213)'],
+  ['highway_motorway_bridge_inner', 'line-color', 'rgb(12, 12, 16)',    '#ffffff'],
+  ['road_area_pier',                'fill-color', 'rgb(8, 8, 12)',      'rgb(242, 243, 240)'],
+  ['road_pier',                     'line-color', 'rgb(8, 8, 12)',      'rgb(242, 243, 240)'],
+  ['railway',                       'line-color', 'rgb(10, 10, 14)',    '#dddddd'],
+  ['railway_dashline',              'line-color', 'rgb(12, 12, 16)',    '#fafafa'],
+  ['railway_transit',               'line-color', 'rgb(10, 10, 14)',    '#dddddd'],
+  ['railway_transit_dashline',      'line-color', 'rgb(12, 12, 16)',    '#fafafa'],
+  ['railway_service',               'line-color', 'rgb(10, 10, 14)',    '#dddddd'],
+  ['railway_service_dashline',      'line-color', 'rgb(12, 12, 16)',    '#fafafa'],
+  ['label_country_1',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
+  ['label_country_1',     'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
+  ['label_country_2',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
+  ['label_country_2',     'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
+  ['label_country_3',     'text-color',       'rgb(35, 35, 45)',    '#000000'],
+  ['label_country_3',     'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
+  ['label_city',          'text-color',       'rgb(35, 35, 45)',    '#000000'],
+  ['label_city',          'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
+  ['label_city_capital',  'text-color',       'rgb(35, 35, 45)',    '#000000'],
+  ['label_city_capital',  'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
+  ['label_town',          'text-color',       'rgb(35, 35, 45)',    '#000000'],
+  ['label_town',          'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
+  ['label_state',         'text-color',       'rgb(35, 35, 45)',    '#333333'],
+  ['label_state',         'text-halo-color',  'rgb(2, 2, 4)',       '#ffffff'],
+  ['waterway_line_label',   'text-halo-color', 'rgba(2, 2, 4, 0.7)',      'rgba(255, 255, 255, 0.7)'],
+  ['waterway_line_label',   'text-color',      'rgb(20, 25, 40)',         'hsl(0, 0%, 66%)'],
+  ['water_name_point_label','text-halo-color', 'rgba(2, 2, 4, 0.7)',      'rgba(255, 255, 255, 0.7)'],
+  ['water_name_point_label','text-color',      'rgb(15, 20, 45)',         '#495e91'],
+  ['water_name_line_label', 'text-halo-color', 'rgba(2, 2, 4, 0.7)',      'rgba(255, 255, 255, 0.7)'],
+  ['water_name_line_label', 'text-color',      'rgb(15, 20, 45)',         '#495e91'],
+];
 
 export const mapStyles = {
   default: {
@@ -41,3 +105,64 @@ export const getMapStyle = (styleKey: MapStyleKey = 'default') => {
 export const getMapStyleName = (styleKey: MapStyleKey = 'default') => {
   return mapStyles[styleKey].name;
 };
+
+/**
+ * Registers a tiled layer with the map, including its source.
+ * Supports both raster and vector tile sources with opacity fade control.
+ * @param map The MapLibre map instance
+ * @param options Configuration for the layer registration
+ */
+export interface RegisterStyleOptions {
+  id: string;
+  tiles: string[];
+  type: 'raster' | 'vector';
+  tileSize?: number;
+  attribution?: string;
+  fadeZoomStart?: number;
+  fadeZoomEnd?: number;
+}
+
+export function registerStyle(map: MaplibreGL.Map, options: RegisterStyleOptions): void {
+  const {
+    id,
+    tiles,
+    type,
+    tileSize = 256,
+    attribution = '',
+    fadeZoomStart = 6,
+    fadeZoomEnd = 10,
+  } = options;
+
+  const sourceId = `${id}-source`;
+  const layerId = `${id}-layer`;
+
+  if (!map.getSource(sourceId)) {
+    map.addSource(sourceId, {
+      type: type as any,
+      tiles,
+      ...(type === 'raster' && { tileSize }),
+      ...(attribution && { attribution }),
+    } as any);
+  }
+
+  if (!map.getLayer(layerId)) {
+    const layerConfig: MaplibreGL.LayerSpecification = {
+      id: layerId,
+      type,
+      source: sourceId,
+      ...(type === 'raster' && {
+        paint: {
+          'raster-opacity': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            fadeZoomStart, 0,
+            fadeZoomEnd, 1,
+          ],
+        },
+      }),
+    } as any;
+
+    map.addLayer(layerConfig);
+  }
+}

--- a/App/frontend/src/mapStyles.ts
+++ b/App/frontend/src/mapStyles.ts
@@ -1,0 +1,43 @@
+﻿/**
+ * Map style configurations for the application
+ */
+
+import type { StyleSpecification } from 'maplibre-gl';
+
+export const mapStyles = {
+  default: {
+    name: 'OpenStreetMap (Raster)',
+    style: {
+      version: 8,
+      sources: {
+        'osm-raster': {
+          type: 'raster',
+          tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+          tileSize: 256,
+          attribution: '© OpenStreetMap contributors',
+        },
+      },
+      layers: [
+        {
+          id: 'osm-raster-layer',
+          type: 'raster',
+          source: 'osm-raster',
+        },
+      ],
+    } as StyleSpecification,
+  },
+  positron: {
+    name: 'Positron',
+    style: '../static/style/mapstyle.json' as string,
+  },
+};
+
+export type MapStyleKey = keyof typeof mapStyles;
+
+export const getMapStyle = (styleKey: MapStyleKey = 'default') => {
+  return mapStyles[styleKey].style;
+};
+
+export const getMapStyleName = (styleKey: MapStyleKey = 'default') => {
+  return mapStyles[styleKey].name;
+};

--- a/App/frontend/src/mapStyles.ts
+++ b/App/frontend/src/mapStyles.ts
@@ -166,3 +166,34 @@ export function registerStyle(map: MaplibreGL.Map, options: RegisterStyleOptions
     map.addLayer(layerConfig);
   }
 }
+
+/**
+ * Toggles a style layer's visibility
+ * @param map The MapLibre map instance
+ * @param id The style id (as used in registerStyle)
+ * @returns The new visibility state (true = visible, false = hidden)
+ */
+export function toggleStyleLayer(map: MaplibreGL.Map, id: string): boolean {
+  const layerId = `${id}-layer`;
+  if (map.getLayer(layerId)) {
+    const currentVisibility = map.getLayoutProperty(layerId, 'visibility') as string;
+    const isVisible = currentVisibility !== 'none';
+    map.setLayoutProperty(layerId, 'visibility', isVisible ? 'none' : 'visible');
+    return !isVisible;
+  }
+  return false;
+}
+
+/**
+ * Gets the current visibility state of a style layer
+ * @param map The MapLibre map instance
+ * @param id The style id (as used in registerStyle)
+ * @returns true if visible, false if hidden or layer doesn't exist
+ */
+export function isStyleLayerVisible(map: MaplibreGL.Map, id: string): boolean {
+  const layerId = `${id}-layer`;
+  const layer = map.getLayer(layerId);
+  if (!layer) return false;
+  const visibility = map.getLayoutProperty(layerId, 'visibility') as string;
+  return visibility !== 'none';
+}

--- a/App/frontend/src/shortestPath.ts
+++ b/App/frontend/src/shortestPath.ts
@@ -1,24 +1,12 @@
 ﻿import type * as MaplibreGL from "maplibre-gl";
 import { AddShortestPathLayer, ClearShortestPathLayer } from "./layer.js";
+import { GraphNode, RoadSegment, CacheBounds } from "./interfaces.js";
 
 let roadNetworkCache: any = null;
-let roadNetworkCacheBounds: { minLat: number; maxLat: number; minLng: number; maxLng: number } | null = null;
+let roadNetworkCacheBounds: CacheBounds | null = null;
 const WGS84_CONSTANT = 20037508.34;
 const ROAD_TYPES = 'Enkel%20bilveg,Bilferje,Rampe,Rundkj%C3%B8ring,Kanalisert%20veg';
 
-interface GraphNode {
-  id: string;
-  neighbors: Array<{ nodeId: string; segment: any }>;
-  lat: number;
-  lng: number;
-}
-
-interface RoadSegment {
-  coordinates: [number, number][];
-  distance: number;
-  start: any;
-  end: any;
-}
 
 const haversineDistance = (lat1: number, lng1: number, lat2: number, lng2: number): number => {
   const R = 6371, dLat = (lat2 - lat1) * Math.PI / 180, dLng = (lng2 - lng1) * Math.PI / 180;

--- a/App/frontend/src/starsLayer.ts
+++ b/App/frontend/src/starsLayer.ts
@@ -1,12 +1,7 @@
 ﻿/**
  * Heavily based on https://github.com/birkskyum/maplibre-gl-stars/tree/main
  */
-
-export interface StarsLayerOptions {
-  id?: string;
-  intensity?: number;
-  density?: number;
-}
+import { StarsLayerOptions } from './interfaces.js';
 
 export function createStarsLayer(options: StarsLayerOptions = {}) {
   const intensity = options.intensity || 20.0;

--- a/App/frontend/tsconfig.json
+++ b/App/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 ﻿{
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2017",
     "module": "es2020",
     "moduleResolution": "node",
     "strict": true,

--- a/App/static/style/style.css
+++ b/App/static/style/style.css
@@ -22,16 +22,17 @@
     color: #fff;
     padding: 4px;
     border-bottom-right-radius: 6px;
-    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial;
     font-size: 12px;
     z-index: 9999;
     pointer-events: auto;
     box-shadow: 0 4px 12px rgba(15,25,30,0.35);
     outline: 2px solid rgba(15,25,30,0.65);
+    -webkit-backdrop-filter: blur(0.5rem);
+    backdrop-filter: blur(0.1rem);
 }
 
 .header {
-    font-family: Tahoma, Geneva, sans-serif;
+    font-family: 'Courier New', 'Monaco', 'Consolas', monospace;
     font-size: 1.5rem; /* ~28px */
     font-weight: 500;
     line-height: 1.2;
@@ -39,7 +40,7 @@
 }
 
 .text {
-    font-family: Tahoma, Geneva, sans-serif;
+    font-family: 'Courier New', 'Monaco', 'Consolas', monospace;
     font-size: 1.0rem;
     line-height: 1.2;
     color: #c2c8ca;
@@ -54,6 +55,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    font-family: 'Courier New', 'Monaco', 'Consolas', monospace;
 }
 
 .button{
@@ -70,7 +72,7 @@
 
 .container {
     display: grid;
-    grid-template-columns: auto auto auto auto;
+    grid-template-columns: auto auto auto auto auto;
     padding: 0.25rem;
     grid-gap: 0;
     max-width: max-content;
@@ -133,7 +135,7 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.4rem 0.65rem;
-    font-family: Tahoma, Geneva, sans-serif;
+    font-family: 'Courier New', 'Monaco', 'Consolas', monospace;
     font-size: 0.85rem;
     color: #c2c8ca;
     cursor: pointer;
@@ -155,7 +157,7 @@
 
 .dropdown-empty {
     padding: 0.5rem 0.65rem;
-    font-family: Tahoma, Geneva, sans-serif;
+    font-family: 'Courier New', 'Monaco', 'Consolas', monospace;
     font-size: 0.8rem;
     color: rgba(194, 200, 202, 0.5);
     font-style: italic;

--- a/App/templates/index.html
+++ b/App/templates/index.html
@@ -11,13 +11,17 @@
 
 <body style="margin: 0;">
   <div id="map" style="width: 100vw; height: 100vh;"></div>
+
   <div class="map-overlay container">
-    <div class="header box prevent-select">Map Application</div>
+    <div class="header box prevent-select">ShelterLog</div>
     <div class="dropdown">
       <div class="box text prevent-select button dropdown-toggle" id="layers-toggle">Layers ▾</div>
     </div>
+    <div class="dropdown">
+      <div class="box text prevent-select button dropdown-toggle" id="styles-toggle">Styles ▾</div>
+    </div>
     <div class="box text prevent-select button" id="shortest-path-btn">
-      <span style="position: relative; z-index: 2;">Find Closest Shelter</span>
+      <span style="position: relative; z-index: 2;">Find Shelter</span>
       <div class="loading-bar"></div>
     </div>
     <div class="box text prevent-select button" id="clear-path-btn" style="display: none;">
@@ -25,6 +29,10 @@
     </div>
   </div>
   <div class="dropdown-menu" id="layers-menu"></div>
+  <div class="dropdown-menu" id="styles-menu">
+    <div class="dropdown-empty">No map styles available</div>
+  </div>
+
   <script type="module" src="{{ url_for('static', filename='js/main.js') }}?v={{ ts }}"
         onerror="let s=document.createElement('script');s.type='module';s.src='../static/js/main.js';document.body.appendChild(s);">
   </script>

--- a/App/templates/index.html
+++ b/App/templates/index.html
@@ -1,40 +1,45 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Title</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='/style/style.css')}}" onerror="href='../static/style/style.css';">
-  <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"></script>
-  <link href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css" rel="stylesheet" />
-</head>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Title</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='/style/style.css')}}" onerror="href='../static/style/style.css';">
+    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"></script>
+    <link href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css" rel="stylesheet" />
+  </head>
 
-<body style="margin: 0;">
-  <div id="map" style="width: 100vw; height: 100vh;"></div>
+  <body style="margin: 0;">
+    <div id="map" style="width: 100vw; height: 100vh;"></div>
+    <div class="map-overlay container">
+      <div class="header box prevent-select">ShelterLog</div>
 
-  <div class="map-overlay container">
-    <div class="header box prevent-select">ShelterLog</div>
-    <div class="dropdown">
-      <div class="box text prevent-select button dropdown-toggle" id="layers-toggle">Layers ▾</div>
-    </div>
-    <div class="dropdown">
-      <div class="box text prevent-select button dropdown-toggle" id="styles-toggle">Styles ▾</div>
-    </div>
-    <div class="box text prevent-select button" id="shortest-path-btn">
-      <span style="position: relative; z-index: 2;">Find Shelter</span>
-      <div class="loading-bar"></div>
-    </div>
-    <div class="box text prevent-select button" id="clear-path-btn" style="display: none;">
-      <span style="position: relative; z-index: 2;">✕</span>
-    </div>
-  </div>
-  <div class="dropdown-menu" id="layers-menu"></div>
-  <div class="dropdown-menu" id="styles-menu">
-    <div class="dropdown-empty">No map styles available</div>
-  </div>
+      <div class="dropdown">
+        <div class="box text prevent-select button dropdown-toggle" id="layers-toggle">Layers ▾</div>
+      </div>
 
-  <script type="module" src="{{ url_for('static', filename='js/main.js') }}?v={{ ts }}"
-        onerror="let s=document.createElement('script');s.type='module';s.src='../static/js/main.js';document.body.appendChild(s);">
-  </script>
-</body>
+      <div class="dropdown">
+        <div class="box text prevent-select button dropdown-toggle" id="styles-toggle">Styles ▾</div>
+      </div>
+
+      <div class="box text prevent-select button" id="shortest-path-btn">
+        <span style="position: relative; z-index: 2;">Find Shelter</span>
+        <div class="loading-bar"></div>
+      </div>
+
+      <div class="box text prevent-select button" id="clear-path-btn" style="display: none;">
+        <span style="position: relative; z-index: 2;">✕</span>
+      </div>
+    </div>
+
+    <div class="dropdown-menu" id="layers-menu"></div>
+
+    <div class="dropdown-menu" id="styles-menu">
+      <div class="dropdown-empty">No map styles available</div>
+    </div>
+
+    <script type="module" src="{{ url_for('static', filename='js/main.js') }}?v={{ ts }}"
+          onerror="let s=document.createElement('script');s.type='module';s.src='../static/js/main.js';document.body.appendChild(s);">
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
This pull request refactors the frontend codebase to modularize and improve the maintainability of map layer and style controls. The main themes are the extraction of layer control logic into a new module, improved type safety and clarity via TypeScript interfaces, and simplification of dropdown menu management. These changes make it easier to add new map layers and styles, and to manage dropdown UI behavior.

**Layer and Style Control Modularization:**

- Extracted all dropdown menu logic, layer registration, and style registration from `layer.ts` into a new module `layerControl.ts`, providing clear, reusable functions for registering layers and styles, and managing dropdown visibility. This includes functions like `initializeDropdownMenus`, `registerLayer`, and `registerStyleInMenu`. (`[[1]](diffhunk://#diff-b40c2e687b1a52ae00373896c0dc632e846f5ac2a0c6dca3476207cf739857a2R1-R144)`, `[[2]](diffhunk://#diff-561499f5e3ef62d10389db34fcbf8277f353409c63f100f6f0e936522a52ac4cL77-R74)`)
- Updated `main.ts` and `layer.ts` to import and use the new functions from `layerControl.ts`, removing duplicated or inlined UI logic. (`[[1]](diffhunk://#diff-bf7bca09c41c73178054a207355fdd8019eec29e3470c28e2f4126051799cf0aL1-R8)`, `[[2]](diffhunk://#diff-561499f5e3ef62d10389db34fcbf8277f353409c63f100f6f0e936522a52ac4cL2-R13)`)

**Type Safety and Interface Improvements:**

- Added a new `interfaces.ts` file defining TypeScript types and interfaces for map features, WMS layer configs, and other map-related data structures, improving type safety and code clarity. (`[App/frontend/src/interfaces.tsR1-R79](diffhunk://#diff-765275b7614a8f4bfeef177cd9d6c2ef8a85a42ccb488b21f1ae337ced78995aR1-R79)`)
- Removed redundant type/interface definitions from `layer.ts`, centralizing them in `interfaces.ts`. (`[App/frontend/src/layer.tsL321-L336](diffhunk://#diff-561499f5e3ef62d10389db34fcbf8277f353409c63f100f6f0e936522a52ac4cL321-L336)`)

**WMS Layer Registration Refactoring:**

- Refactored WMS layer registration logic in `layer.ts` to use a generic `addWmsLayers` function, reducing code duplication and making it easier to add new WMS layers. Wrapper functions now call this generic function. (`[[1]](diffhunk://#diff-561499f5e3ef62d10389db34fcbf8277f353409c63f100f6f0e936522a52ac4cL77-R74)`, `[[2]](diffhunk://#diff-561499f5e3ef62d10389db34fcbf8277f353409c63f100f6f0e936522a52ac4cL165-R163)`)

**Dropdown UI and Initialization Improvements:**

- Improved dropdown menu logic to ensure only one menu is open at a time, and made the UI behavior more robust by centralizing event handling in `layerControl.ts`. (`[App/frontend/src/layerControl.tsR1-R144](diffhunk://#diff-b40c2e687b1a52ae00373896c0dc632e846f5ac2a0c6dca3476207cf739857a2R1-R144)`)
- Updated `main.ts` to call `initializeDropdownMenus` on startup, ensuring dropdowns are properly initialized. (`[App/frontend/src/main.tsL30-R36](diffhunk://#diff-bf7bca09c41c73178054a207355fdd8019eec29e3470c28e2f4126051799cf0aL30-R36)`)

**Map Style Registration Enhancements:**

- Added registration of an OSM raster layer and its corresponding style menu entry, using the new modular functions, making it easier to add and toggle map styles. (`[App/frontend/src/main.tsR87-R100](diffhunk://#diff-bf7bca09c41c73178054a207355fdd8019eec29e3470c28e2f4126051799cf0aR87-R100)`)

These changes collectively improve code organization, reusability, and maintainability, especially as the map UI grows in complexity.

**References:**  
[[1]](diffhunk://#diff-b40c2e687b1a52ae00373896c0dc632e846f5ac2a0c6dca3476207cf739857a2R1-R144) [[2]](diffhunk://#diff-561499f5e3ef62d10389db34fcbf8277f353409c63f100f6f0e936522a52ac4cL77-R74) [[3]](diffhunk://#diff-561499f5e3ef62d10389db34fcbf8277f353409c63f100f6f0e936522a52ac4cL2-R13) [[4]](diffhunk://#diff-765275b7614a8f4bfeef177cd9d6c2ef8a85a42ccb488b21f1ae337ced78995aR1-R79) [[5]](diffhunk://#diff-561499f5e3ef62d10389db34fcbf8277f353409c63f100f6f0e936522a52ac4cL321-L336) [[6]](diffhunk://#diff-561499f5e3ef62d10389db34fcbf8277f353409c63f100f6f0e936522a52ac4cL165-R163) [[7]](diffhunk://#diff-bf7bca09c41c73178054a207355fdd8019eec29e3470c28e2f4126051799cf0aL1-R8) [[8]](diffhunk://#diff-bf7bca09c41c73178054a207355fdd8019eec29e3470c28e2f4126051799cf0aL30-R36) [[9]](diffhunk://#diff-bf7bca09c41c73178054a207355fdd8019eec29e3470c28e2f4126051799cf0aR87-R100)