### PR TITLE
Feature/shelter check

### DIFF
--- a/App/frontend/package-lock.json
+++ b/App/frontend/package-lock.json
@@ -337,9 +337,9 @@
       "license": "ISC"
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "license": "MIT"
     },
     "node_modules/quickselect": {


### PR DESCRIPTION
This pull request updates the `protocol-buffers-schema` dependency in the frontend's `package-lock.json` file from version 3.6.0 to 3.6.1. This is a minor dependency upgrade and should not introduce breaking changes.