### PR TITLE
Feat/getbuilding

### DIFF
--- a/App/app.py
+++ b/App/app.py
@@ -283,6 +283,57 @@ def api_exclusion_zones():
         traceback.print_exc()
         return flask.jsonify({"type": "FeatureCollection", "features": []})
 
+@app.route('/api/amenities')
+def api_amenities():
+    """Get amenities by type as GeoJSON FeatureCollection(s).
+
+    Query parameters:
+        type: Optional single amenity type (e.g., 'convenience', 'doctors')
+        types: Optional comma-separated list of amenity types
+        organized: If true, returns dictionary with layers for each type (default: false)
+    """
+    amenity_type = flask.request.args.get('type', '').strip()
+    amenity_types_param = flask.request.args.get('types', '').strip()
+    organized = flask.request.args.get('organized', 'false').lower() == 'true'
+
+    amenity_types = None
+    if amenity_types_param:
+        amenity_types = [t.strip() for t in amenity_types_param.split(',') if t.strip()]
+    elif amenity_type:
+        amenity_types = [amenity_type]
+
+    try:
+        engine = database.create_engine()
+
+        if organized and not amenity_type and not amenity_types_param:
+            # Return organized by type
+            geojson = database.get_amenities_by_type(engine)
+        else:
+            # Return single FeatureCollection
+            geojson = database.get_amenities_by_type(engine, amenity_type=amenity_type, amenity_types=amenity_types)
+
+        return flask.jsonify(geojson)
+    except Exception as e:
+        print(f"Error fetching amenities: {e}")
+        traceback.print_exc()
+        return flask.jsonify({"type": "FeatureCollection", "features": []})
+
+@app.route('/api/amenities/<amenity_type>')
+def api_amenities_by_type(amenity_type):
+    """Get amenities of a specific type as GeoJSON FeatureCollection.
+
+    Args:
+        amenity_type: The amenity type (e.g., 'convenience', 'doctors', 'drinking_water', 'hardware', 'supermarket', 'trade')
+    """
+    try:
+        engine = database.create_engine()
+        geojson = database.get_amenities_by_type(engine, amenity_type=amenity_type)
+        return flask.jsonify(geojson)
+    except Exception as e:
+        print(f"Error fetching amenities of type {amenity_type}: {e}")
+        traceback.print_exc()
+        return flask.jsonify({"type": "FeatureCollection", "features": []})
+
 @app.route('/api/nvdb/roads')
 def api_nvdb_roads():
     """Fetch NVDB road segments as GeoJSON from PostGIS.

--- a/App/database.py
+++ b/App/database.py
@@ -487,6 +487,7 @@ class AmenityType(Enum):
     SUPERMARKET = "supermarket"
     TRADE = "trade"
     HOSPITAL = "hospital"
+    CHEMIST = "chemist"
 
 
 def get_amenities_by_type(engine, amenity_type: str | AmenityType = None, amenity_types: list[str] = None):
@@ -503,15 +504,7 @@ def get_amenities_by_type(engine, amenity_type: str | AmenityType = None, amenit
         If amenity_type or amenity_types is specified:
             A FeatureCollection for those types
         If neither is specified:
-            A dictionary with layers for each amenity type:
-            {
-                "convenience": FeatureCollection,
-                "doctors": FeatureCollection,
-                "drinking_water": FeatureCollection,
-                "hardware": FeatureCollection,
-                "supermarket": FeatureCollection,
-                "trade": FeatureCollection
-            }
+            A dictionary with layers for each amenity type
     """
 
     # Convert AmenityType enum to string if needed
@@ -519,91 +512,55 @@ def get_amenities_by_type(engine, amenity_type: str | AmenityType = None, amenit
         amenity_type = amenity_type.value
 
     # Build the list of types to query
-    types_to_query = None
     if amenity_types:
         types_to_query = amenity_types
     elif amenity_type:
         types_to_query = [amenity_type]
     else:
-        types_to_query = list(AmenityType)
+        types_to_query = [e.value for e in AmenityType]
+
+    # Determine if organizing by type
+    organize_by_type = not (amenity_type or amenity_types)
+    order_by = "key, fid" if organize_by_type else "fid"
 
     with engine.connect() as conn:
-        if amenity_type or amenity_types:
-            # Get specific amenity type(s) as single FeatureCollection
-            query = text("""
-                SELECT 
-                    fid,
-                    key,
-                    ST_AsGeoJSON(wkt_geom::geometry) AS geojson
-                FROM public.buildings
-                WHERE key = ANY(:amenity_types)
-                ORDER BY fid;
-            """)
-            rows = conn.execute(query, {"amenity_types": types_to_query}).fetchall()
+        query = text(f"""
+            SELECT fid, key, ST_AsGeoJSON(wkt_geom::geometry) AS geojson
+            FROM public.buildings
+            WHERE key = ANY(:amenity_types)
+            ORDER BY {order_by};
+        """)
+        rows = conn.execute(query, {"amenity_types": types_to_query}).fetchall()
 
+        # If not organizing by type, return simple FeatureCollection
+        if not organize_by_type:
             features = []
             for row in rows:
                 try:
-                    geojson = json.loads(row[2])
                     feature = {
                         "type": "Feature",
-                        "geometry": geojson,
-                        "properties": {
-                            "fid": int(row[0]),
-                            "type": row[1]
-                        }
+                        "geometry": json.loads(row[2]),
+                        "properties": {"fid": int(row[0]), "type": row[1]}
                     }
                     features.append(feature)
                 except Exception as e:
                     print(f"Error parsing amenity {row[0]}: {e}")
-                    continue
+            return {"type": "FeatureCollection", "features": features}
 
-            return {
-                "type": "FeatureCollection",
-                "features": features
-            }
-        else:
-            # Get all amenities organized by type
-            query = text("""
-                SELECT 
-                    fid,
-                    key,
-                    ST_AsGeoJSON(wkt_geom::geometry) AS geojson
-                FROM public.buildings
-                WHERE key = ANY(:amenity_types)
-                ORDER BY key, fid;
-            """)
-            rows = conn.execute(query, {"amenity_types": types_to_query}).fetchall()
+        # Organize by type
+        layers = {e.value: {"type": "FeatureCollection", "features": []} for e in AmenityType}
 
-            layers = {
-                "convenience": {"type": "FeatureCollection", "features": []},
-                "doctors": {"type": "FeatureCollection", "features": []},
-                "drinking_water": {"type": "FeatureCollection", "features": []},
-                "hardware": {"type": "FeatureCollection", "features": []},
-                "supermarket": {"type": "FeatureCollection", "features": []},
-                "trade": {"type": "FeatureCollection", "features": []}
-            }
+        for row in rows:
+            try:
+                amenity_type_str = row[1]
+                feature = {
+                    "type": "Feature",
+                    "geometry": json.loads(row[2]),
+                    "properties": {"fid": int(row[0]), "type": amenity_type_str}
+                }
+                if amenity_type_str in layers:
+                    layers[amenity_type_str]["features"].append(feature)
+            except Exception as e:
+                print(f"Error parsing amenity {row[0]}: {e}")
 
-            for row in rows:
-                try:
-                    geojson = json.loads(row[2])
-                    amenity_type_str = row[1]
-
-                    feature = {
-                        "type": "Feature",
-                        "geometry": geojson,
-                        "properties": {
-                            "fid": int(row[0]),
-                            "type": amenity_type_str
-                        }
-                    }
-
-                    if amenity_type_str in layers:
-                        layers[amenity_type_str]["features"].append(feature)
-                except Exception as e:
-                    print(f"Error parsing amenity {row[0]}: {e}")
-                    continue
-
-            return layers
-
-print(get_amenities_by_type(create_engine(), AmenityType.CONVENIENCE))
+        return layers

--- a/App/database.py
+++ b/App/database.py
@@ -476,3 +476,134 @@ def get_exclusion_zones(engine):
             "type": "FeatureCollection",
             "features": features
         }
+
+
+# Amenity types as defined in the request
+class AmenityType(Enum):
+    CONVENIENCE = "convenience"
+    DOCTORS = "doctors"
+    DRINKING_WATER = "drinking_water"
+    HARDWARE = "hardware"
+    SUPERMARKET = "supermarket"
+    TRADE = "trade"
+    HOSPITAL = "hospital"
+
+
+def get_amenities_by_type(engine, amenity_type: str | AmenityType = None, amenity_types: list[str] = None):
+    """
+    Retrieve amenities from the database and return them organized by type as layers.
+
+    Args:
+        engine: SQLAlchemy engine instance
+        amenity_type: Optional single amenity type filter (e.g., 'convenience', 'doctors')
+        amenity_types: Optional list of amenity types to filter (e.g., ['convenience', 'doctors'])
+                     If neither amenity_type nor amenity_types is provided, returns all types.
+
+    Returns:
+        If amenity_type or amenity_types is specified:
+            A FeatureCollection for those types
+        If neither is specified:
+            A dictionary with layers for each amenity type:
+            {
+                "convenience": FeatureCollection,
+                "doctors": FeatureCollection,
+                "drinking_water": FeatureCollection,
+                "hardware": FeatureCollection,
+                "supermarket": FeatureCollection,
+                "trade": FeatureCollection
+            }
+    """
+
+    # Convert AmenityType enum to string if needed
+    if isinstance(amenity_type, AmenityType):
+        amenity_type = amenity_type.value
+
+    # Build the list of types to query
+    types_to_query = None
+    if amenity_types:
+        types_to_query = amenity_types
+    elif amenity_type:
+        types_to_query = [amenity_type]
+    else:
+        types_to_query = list(AmenityType)
+
+    with engine.connect() as conn:
+        if amenity_type or amenity_types:
+            # Get specific amenity type(s) as single FeatureCollection
+            query = text("""
+                SELECT 
+                    fid,
+                    key,
+                    ST_AsGeoJSON(wkt_geom::geometry) AS geojson
+                FROM public.buildings
+                WHERE key = ANY(:amenity_types)
+                ORDER BY fid;
+            """)
+            rows = conn.execute(query, {"amenity_types": types_to_query}).fetchall()
+
+            features = []
+            for row in rows:
+                try:
+                    geojson = json.loads(row[2])
+                    feature = {
+                        "type": "Feature",
+                        "geometry": geojson,
+                        "properties": {
+                            "fid": int(row[0]),
+                            "type": row[1]
+                        }
+                    }
+                    features.append(feature)
+                except Exception as e:
+                    print(f"Error parsing amenity {row[0]}: {e}")
+                    continue
+
+            return {
+                "type": "FeatureCollection",
+                "features": features
+            }
+        else:
+            # Get all amenities organized by type
+            query = text("""
+                SELECT 
+                    fid,
+                    key,
+                    ST_AsGeoJSON(wkt_geom::geometry) AS geojson
+                FROM public.buildings
+                WHERE key = ANY(:amenity_types)
+                ORDER BY key, fid;
+            """)
+            rows = conn.execute(query, {"amenity_types": types_to_query}).fetchall()
+
+            layers = {
+                "convenience": {"type": "FeatureCollection", "features": []},
+                "doctors": {"type": "FeatureCollection", "features": []},
+                "drinking_water": {"type": "FeatureCollection", "features": []},
+                "hardware": {"type": "FeatureCollection", "features": []},
+                "supermarket": {"type": "FeatureCollection", "features": []},
+                "trade": {"type": "FeatureCollection", "features": []}
+            }
+
+            for row in rows:
+                try:
+                    geojson = json.loads(row[2])
+                    amenity_type_str = row[1]
+
+                    feature = {
+                        "type": "Feature",
+                        "geometry": geojson,
+                        "properties": {
+                            "fid": int(row[0]),
+                            "type": amenity_type_str
+                        }
+                    }
+
+                    if amenity_type_str in layers:
+                        layers[amenity_type_str]["features"].append(feature)
+                except Exception as e:
+                    print(f"Error parsing amenity {row[0]}: {e}")
+                    continue
+
+            return layers
+
+print(get_amenities_by_type(create_engine(), AmenityType.CONVENIENCE))

--- a/App/frontend/src/enum.ts
+++ b/App/frontend/src/enum.ts
@@ -5,7 +5,8 @@
   HARDWARE = 'hardware',
   SUPERMARKET = 'supermarket',
   TRADE = 'trade',
-  HOSPITAL = 'hospital'
+  HOSPITAL = 'hospital',
+  CHEMIST = 'chemist'
 }
 
 export enum ExclusionZoneType {
@@ -27,7 +28,8 @@ export enum amenityColor {
   'hardware' = '#8E44AD',
   'supermarket' = '#27AE60',
   'trade' = '#F39C12',
-  'hospital' = '#C0392B'
+  'hospital' = '#C0392B',
+  'chemist' = '#2ECC71'
 }
 
 export enum exclusionZoneColor {

--- a/App/frontend/src/enum.ts
+++ b/App/frontend/src/enum.ts
@@ -1,4 +1,14 @@
-﻿export enum ExclusionZoneType {
+﻿export enum AmenityType {
+  CONVENIENCE = 'convenience',
+  DOCTORS = 'doctors',
+  DRINKING_WATER = 'drinking_water',
+  HARDWARE = 'hardware',
+  SUPERMARKET = 'supermarket',
+  TRADE = 'trade',
+  HOSPITAL = 'hospital'
+}
+
+export enum ExclusionZoneType {
   'Flood Zone'        = 1,
   'Radiation Hazard'  = 2,
   'Biological Hazard' = 3,
@@ -10,6 +20,16 @@
 }
 
 //region Config
+export enum amenityColor {
+  'convenience' = '#FF9800',
+  'doctors' = '#E74C3C',
+  'drinking_water' = '#3498DB',
+  'hardware' = '#8E44AD',
+  'supermarket' = '#27AE60',
+  'trade' = '#F39C12',
+  'hospital' = '#C0392B'
+}
+
 export enum exclusionZoneColor {
   'Flood Zone'        = '#0000ff',
   'Radiation Hazard'  = '#e1ca43',

--- a/App/frontend/src/layer.ts
+++ b/App/frontend/src/layer.ts
@@ -471,3 +471,108 @@ export function AddExclusionZonesLayer(map: MaplibreGL.Map, geojsonData: GeoJSON
     return this;
   };
 }
+
+/**
+ * Adds amenity layers to the map for each amenity type.
+ * Supports displaying convenience stores, doctors, drinking water, hardware, supermarkets, and trade facilities.
+ * @param map The MapLibre map instance
+ * @param amenityTypes Optional array of specific amenity types to load. If not provided, loads all types.
+ * @param visible Controls if the layers are displayed once they've been loaded
+ */
+export async function AddAmenityLayers(
+  map: MaplibreGL.Map,
+  amenityTypes?: string[],
+  visible: boolean = false
+): Promise<void> {
+  const { AmenityType, amenityColor } = await import('./enum.js');
+
+  // Use all types if not specified
+  const typesToLoad = amenityTypes || Object.values(AmenityType);
+  const layerVisibility = visible ? 'visible' : 'none';
+
+  // Friendly display names for amenity types
+  const amenityLabels: Record<string, string> = {
+    'convenience': 'Convenience Store',
+    'doctors': 'Doctor',
+    'drinking_water': 'Drinking Water',
+    'hardware': 'Hardware Stores',
+    'supermarket': 'Supermarket',
+    'trade': 'Trade Store',
+    'hospital': 'Hospital'
+  };
+
+  for (const amenityType of typesToLoad) {
+    try {
+      const res = await fetch(`/api/amenities/${amenityType}`);
+      const geojson = await res.json();
+
+      if (!geojson.features || geojson.features.length === 0) {
+        console.warn(`No amenities found for type: ${amenityType}`);
+        continue;
+      }
+
+      const sourceId = `amenity-source-${amenityType}`;
+      const layerId = `amenity-layer-${amenityType}`;
+      const label = amenityLabels[amenityType] || amenityType;
+
+      // Get color for this amenity type
+      const color = (amenityColor as Record<string, string>)[amenityType] || '#808080';
+
+      // Add the source
+      map.addSource(sourceId, { type: 'geojson', data: geojson });
+
+      // Add the layer
+      map.addLayer({
+        id: layerId,
+        type: 'circle',
+        source: sourceId,
+        paint: {
+          'circle-radius': 5,
+          'circle-color': color,
+          'circle-stroke-width': 1,
+          'circle-stroke-color': '#ffffff',
+          'circle-opacity': 0.8,
+        },
+        layout: { visibility: layerVisibility },
+      });
+
+      // Create popup on click
+      map.on('click', layerId, (e) => {
+        if (!e.features || e.features.length === 0) return;
+        const feature = e.features[0];
+        const coords = (feature.geometry as GeoJSON.Point).coordinates.slice() as [number, number];
+        const props = feature.properties || {} as Record<string, string>;
+
+        const html = `
+          <div style="font-family: sans-serif; max-width: 200px;">
+            <h3 style="margin: 0 0 6px 0; font-size: 14px;">${label}</h3>
+            <p style="margin: 2px 0;"><strong>Type:</strong> ${props.type || 'Unknown'}</p>
+            <p style="margin: 2px 0;"><strong>Coordinates:</strong> ${coords[1].toFixed(6)}, ${coords[0].toFixed(6)}</p>
+          </div>`;
+
+        // Handle date line wrapping if needed
+        if (e.lngLat) {
+          while (Math.abs(e.lngLat.lng - coords[0]) > 180) {
+            coords[0] += e.lngLat.lng > coords[0] ? 360 : -360;
+          }
+        }
+
+        if (maplibregl) {
+          new maplibregl.Popup({ offset: 10 }).setLngLat(coords).setHTML(html).addTo(map);
+        }
+      });
+
+      // Change cursor on hover
+      map.on('mouseenter', layerId, () => { map.getCanvas().style.cursor = 'pointer'; });
+      map.on('mouseleave', layerId, () => { map.getCanvas().style.cursor = ''; });
+
+      // Register the layer in the layer control
+      registerLayer(layerId, label, visible, map);
+
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+    } catch (err) {
+      console.error(`Failed to load amenities for type ${amenityType}:`, err);
+    }
+  }
+}

--- a/App/frontend/src/layer.ts
+++ b/App/frontend/src/layer.ts
@@ -493,12 +493,13 @@ export async function AddAmenityLayers(
   // Friendly display names for amenity types
   const amenityLabels: Record<string, string> = {
     'convenience': 'Convenience Store',
-    'doctors': 'Doctor',
+    'doctors': 'Doctors clinic',
     'drinking_water': 'Drinking Water',
-    'hardware': 'Hardware Stores',
+    'hardware': 'Hardware Store',
     'supermarket': 'Supermarket',
     'trade': 'Trade Store',
-    'hospital': 'Hospital'
+    'hospital': 'Hospital',
+    'chemist': 'Pharmacy',
   };
 
   for (const amenityType of typesToLoad) {

--- a/App/frontend/src/main.ts
+++ b/App/frontend/src/main.ts
@@ -5,6 +5,7 @@ import {
   AddDSBWmsLayers,
   AddVannOgVassdragLayers,
   AddFKBVeiLayer,
+  AddAmenityLayers,
 } from './layer.js'
 import {registerStyleInMenu, initializeDropdownMenus} from './layerControl.js'
 import {registerStyle} from "./mapStyles.js";
@@ -195,6 +196,7 @@ if (!maplibregl) {
     (async () => {
       await initializeExclusionZones(map);
       await AddShelterLayerGeospatial(map, fylkeIds);
+      await AddAmenityLayers(map);
       AddDSBWmsLayers(map);
       AddVannOgVassdragLayers(map);
       AddFKBVeiLayer(map);


### PR DESCRIPTION
This pull request introduces support for displaying amenities (such as convenience stores, doctors, and hospitals) as interactive layers on the frontend map. It adds new backend API endpoints for querying amenities by type, updates the database logic to organize and filter amenities, and extends the frontend to render these amenities with color coding and popups.

**Backend API and database enhancements:**

* Added two new Flask API endpoints: `/api/amenities` (with filtering and organization options) and `/api/amenities/<amenity_type>` to serve amenity data as GeoJSON FeatureCollections.
* Implemented the `get_amenities_by_type` function in `database.py` to fetch amenities from the database, supporting filtering by single or multiple types and organizing results by type. Introduced an `AmenityType` enum for type safety and clarity.

**Frontend enum and color configuration:**

* Added `AmenityType` and `amenityColor` enums in `enum.ts` to standardize amenity types and their associated colors for consistent use across the frontend. [[1]](diffhunk://#diff-62013b3b2b14705a0d18f902f20ef2a70380df507b382a206c63219e4c18b335L1-R12) [[2]](diffhunk://#diff-62013b3b2b14705a0d18f902f20ef2a70380df507b382a206c63219e4c18b335R24-R34)

**Frontend map layer integration:**

* Introduced the `AddAmenityLayers` function in `layer.ts` to fetch amenity data from the backend and add corresponding colored, interactive layers to the map. Each amenity type is shown with a popup and a legend label.
* Integrated `AddAmenityLayers` into the map initialization sequence in `main.ts`, so amenities are displayed when the map loads. [[1]](diffhunk://#diff-bf7bca09c41c73178054a207355fdd8019eec29e3470c28e2f4126051799cf0aR8) [[2]](diffhunk://#diff-bf7bca09c41c73178054a207355fdd8019eec29e3470c28e2f4126051799cf0aR199)